### PR TITLE
Allow skipping patches

### DIFF
--- a/pkg/azureupdate/common.go
+++ b/pkg/azureupdate/common.go
@@ -74,9 +74,10 @@ func upgradeAllowed(g8sclient versioned.Interface, oldVersion semver.Version, ne
 				}
 				// Look for a release with higher major or higher minor than the oldVersion and is LT the newVersion
 				if release.GT(oldVersion) && release.LT(newVersion) &&
-					(oldVersion.Major != release.Major || oldVersion.Minor != release.Minor) {
-					// Skipped one release.
-					return false, microerror.Maskf(invalidOperationError, "Updraging from %s to %s is not allowed (skipped %s)", oldVersion, newVersion, release)
+					(oldVersion.Major != release.Major || oldVersion.Minor != release.Minor) &&
+					(newVersion.Major != release.Major || newVersion.Minor != release.Minor) {
+					// Skipped one major or minor release.
+					return false, microerror.Maskf(invalidOperationError, "Upgrading from %s to %s is not allowed (skipped %s)", oldVersion, newVersion, release)
 				}
 			}
 		}

--- a/pkg/azureupdate/validate_azureclusterconfig_test.go
+++ b/pkg/azureupdate/validate_azureclusterconfig_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestAzureClusterConfigValidate(t *testing.T) {
-	releases := []string{"11.3.0", "11.3.1", "11.4.0", "12.0.0"}
+	releases := []string{"11.3.0", "11.3.1", "11.4.0", "12.0.0", "12.0.1", "12.1.0"}
 
 	testCases := []struct {
 		name         string
@@ -179,6 +179,26 @@ func TestAzureClusterConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.3",
 			newVersion:   "11.4.0",
 			conditions:   []string{"Creating"},
+			allowed:      false,
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name: "case 15",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "11.4.0",
+			newVersion:   "12.0.1",
+			allowed:      true,
+			errorMatcher: nil,
+		},
+		{
+			name: "case 16",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "11.4.0",
+			newVersion:   "12.1.0",
 			allowed:      false,
 			errorMatcher: IsInvalidOperationError,
 		},


### PR DESCRIPTION
While testing Azure 12.0.1, upgrade from 11.4.0 got declined by admission webhook with

```
could not upgrade cluster error: Unknown error: [PATCH /v4/clusters/{cluster_id}/][400] modifyClusterBadRequest  &{Code:INVALID_INPUT Message:The cluster could not be updated. (invalid request error: invalid request error: invalid request error: admission webhook "azureclusterconfigs.azure-admission-controller-unique.giantswarm.io" denied the request: invalid operation error: Updraging from 11.4.0 to 12.0.1 is not allowed (skipped 12.0.0))}
```

12.0.1 deactivates 12.0.0, and is perfectly safe to be upgraded to from 11.4.0

This PR changes the admission webhook to allow skipping (typically deactivated) patch releases.