### PR TITLE
Validate Availability Zones for MachinePool CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure failureDomains in MachinePool are supported by the AzureMachinePool VM type in the current location.
+
 ## [1.8.0] - 2020-10-20
 
 ### Added

--- a/helm/azure-admission-controller/templates/rbac.yaml
+++ b/helm/azure-admission-controller/templates/rbac.yaml
@@ -43,6 +43,12 @@ rules:
       - azureclusters
     verbs:
       - "*"
+  - apiGroups:
+      - exp.cluster.x-k8s.io
+    resources:
+      - machinepools
+    verbs:
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/azure-admission-controller/templates/rbac.yaml
+++ b/helm/azure-admission-controller/templates/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   - apiGroups:
       - exp.infrastructure.cluster.x-k8s.io
     resources:
-      - azuremachinepool
+      - azuremachinepools
     verbs:
       - "*"
   - apiGroups:

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -191,7 +191,7 @@ webhooks:
         path: /validate/machinepool/create
       caBundle: Cg==
     rules:
-      - apiGroups: ["exp.cluster.x-k8s.io/v1alpha3"]
+      - apiGroups: ["exp.cluster.x-k8s.io"]
         resources:
           - "machinepools"
         apiVersions:
@@ -209,7 +209,7 @@ webhooks:
         path: /validate/machinepool/update
       caBundle: Cg==
     rules:
-      - apiGroups: ["exp.cluster.x-k8s.io/v1alpha3"]
+      - apiGroups: ["exp.cluster.x-k8s.io"]
         resources:
           - "machinepools"
         apiVersions:

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -182,3 +182,39 @@ webhooks:
           - UPDATE
     sideEffects: None
     admissionReviewVersions: ["v1", "v1beta1"]
+  - name: validate.machinepools.create.{{ include "resource.default.name" . }}.giantswarm.io
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: {{ include "resource.default.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /validate/machinepool/create
+      caBundle: Cg==
+    rules:
+      - apiGroups: ["exp.cluster.x-k8s.io/v1alpha3"]
+        resources:
+          - "machinepools"
+        apiVersions:
+          - "v1alpha3"
+        operations:
+          - CREATE
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]
+  - name: validate.machinepools.update.{{ include "resource.default.name" . }}.giantswarm.io
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        name: {{ include "resource.default.name" . }}
+        namespace: {{ include "resource.default.namespace" . }}
+        path: /validate/machinepool/update
+      caBundle: Cg==
+    rules:
+      - apiGroups: ["exp.cluster.x-k8s.io/v1alpha3"]
+        resources:
+          - "machinepools"
+        apiVersions:
+          - "v1alpha3"
+        operations:
+          - UPDATE
+    sideEffects: None
+    admissionReviewVersions: ["v1", "v1beta1"]

--- a/internal/vmcapabilities/vmsku.go
+++ b/internal/vmcapabilities/vmsku.go
@@ -100,6 +100,22 @@ func (v *VMSKU) Memory(ctx context.Context, location string, vmType string) (int
 	return 0, microerror.Mask(invalidUpstreamResponseError)
 }
 
+func (v *VMSKU) SupportedAZs(ctx context.Context, location string, vmType string) ([]string, error) {
+	sku, err := v.getSKU(ctx, location, vmType)
+	if err != nil {
+		return []string{}, nil
+	}
+
+	var azs []string
+	for _, l := range *sku.LocationInfo {
+		for _, z := range *l.Zones {
+			azs = append(azs, z)
+		}
+	}
+
+	return azs, nil
+}
+
 func (v *VMSKU) getCapability(ctx context.Context, location string, vmType string, name string) (*string, error) {
 	if name == "" {
 		return nil, microerror.Maskf(invalidRequestError, "name can't be empty")

--- a/internal/vmcapabilities/vmsku.go
+++ b/internal/vmcapabilities/vmsku.go
@@ -108,8 +108,8 @@ func (v *VMSKU) SupportedAZs(ctx context.Context, location string, vmType string
 
 	var azs []string
 	for _, l := range *sku.LocationInfo {
-		for _, z := range *l.Zones {
-			azs = append(azs, z)
+		if l.Zones != nil {
+			azs = append(azs, *l.Zones...)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	restclient "k8s.io/client-go/rest"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/config"
@@ -66,7 +66,7 @@ func mainError() error {
 				providerv1alpha1.AddToScheme,
 				corev1alpha1.AddToScheme,
 				releasev1alpha1.AddToScheme,
-				expcapiv1alpha3.AddToScheme,
+				expcapzv1alpha3.AddToScheme,
 			},
 			Logger: newLogger,
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	restclient "k8s.io/client-go/rest"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/config"
@@ -65,6 +66,7 @@ func mainError() error {
 				providerv1alpha1.AddToScheme,
 				corev1alpha1.AddToScheme,
 				releasev1alpha1.AddToScheme,
+				expcapiv1alpha3.AddToScheme,
 			},
 			Logger: newLogger,
 

--- a/pkg/machinepool/error.go
+++ b/pkg/machinepool/error.go
@@ -1,0 +1,41 @@
+package machinepool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var azureMachinePoolNotFoundError = &microerror.Error{
+	Kind: "azureMachinePoolNotFoundError",
+}
+
+// IsAzureMachinePoolNotFound asserts azureMachinePoolNotFoundError.
+func IsAzureMachinePoolNotFound(err error) bool {
+	return microerror.Cause(err) == azureMachinePoolNotFoundError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidOperationError = &microerror.Error{
+	Kind: "invalidOperationError",
+}
+
+// IsInvalidOperationError asserts invalidOperationError.
+func IsInvalidOperationError(err error) bool {
+	return microerror.Cause(err) == invalidOperationError
+}
+
+var parsingFailedError = &microerror.Error{
+	Kind: "parsingFailedError",
+}
+
+// IsParsingFailed asserts parsingFailedError.
+func IsParsingFailed(err error) bool {
+	return microerror.Cause(err) == parsingFailedError
+}

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -66,8 +66,11 @@ func (a *CreateValidator) Log(keyVals ...interface{}) {
 
 func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *v1alpha3.MachinePool) error {
 	// Get the AzureMachinePool CR related to this MachinePool (we need it to get the VM type).
+	if mp.Spec.Template.Spec.InfrastructureRef.Namespace == "" || mp.Spec.Template.Spec.InfrastructureRef.Name == "" {
+		return microerror.Maskf(azureMachinePoolNotFoundError, "MachinePool's InfrastructureRef has to be set")
+	}
 	amp := expcapzv1alpha3.AzureMachinePool{}
-	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Namespace, Name: mp.Name}, &amp)
+	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
 	if err != nil {
 		return microerror.Maskf(azureMachinePoolNotFoundError, "AzureMachinePool has to be created before the related MachinePool")
 	}

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -74,6 +74,7 @@ func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *v1alph
 	amp := expcapzv1alpha3.AzureMachinePool{}
 	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
 	if err != nil {
+		a.logger.LogCtx(ctx, "level", "debug", "message", err.Error())
 		return microerror.Maskf(azureMachinePoolNotFoundError, "AzureMachinePool has to be created before the related MachinePool")
 	}
 

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -2,7 +2,6 @@ package machinepool
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -70,11 +69,9 @@ func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *v1alph
 	if mp.Spec.Template.Spec.InfrastructureRef.Namespace == "" || mp.Spec.Template.Spec.InfrastructureRef.Name == "" {
 		return microerror.Maskf(azureMachinePoolNotFoundError, "MachinePool's InfrastructureRef has to be set")
 	}
-	a.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Looking for AzureMachinePool %s in namespace %s", mp.Spec.Template.Spec.InfrastructureRef.Name, mp.Spec.Template.Spec.InfrastructureRef.Namespace))
 	amp := expcapzv1alpha3.AzureMachinePool{}
 	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
 	if err != nil {
-		a.logger.LogCtx(ctx, "level", "debug", "message", err.Error())
 		return microerror.Maskf(azureMachinePoolNotFoundError, "AzureMachinePool has to be created before the related MachinePool")
 	}
 

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -1,0 +1,97 @@
+package machinepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+)
+
+type CreateValidator struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	vmcaps     *vmcapabilities.VMSKU
+}
+
+type CreateValidatorConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	VMcaps     *vmcapabilities.VMSKU
+}
+
+func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.VMcaps == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
+	}
+
+	admitter := &CreateValidator{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		vmcaps:     config.VMcaps,
+	}
+
+	return admitter, nil
+}
+
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+	machinePoolNewCR := &v1alpha3.MachinePool{}
+	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+	}
+
+	err := a.checkAvailabilityZones(ctx, machinePoolNewCR)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func (a *CreateValidator) Log(keyVals ...interface{}) {
+	a.logger.Log(keyVals...)
+}
+
+func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *v1alpha3.MachinePool) error {
+	// Get the AzureMachinePool CR related to this MachinePool (we need it to get the VM type).
+	amp := expcapzv1alpha3.AzureMachinePool{}
+	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Namespace, Name: mp.Name}, &amp)
+	if err != nil {
+		return microerror.Maskf(azureMachinePoolNotFoundError, "AzureMachinePool has to be created before the related MachinePool")
+	}
+
+	supportedZones, err := a.vmcaps.SupportedAZs(ctx, amp.Spec.Location, amp.Spec.Template.VMSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, zone := range mp.Spec.FailureDomains {
+		if !inSlice(zone, supportedZones) {
+			// Found one unsupported availability zone requested.
+			return microerror.Maskf(invalidOperationError, "You requested the Machine Pool with type %s to be placed in the following FailureDomains (aka Availability zones): %v but the VM type only supports %v in %s", amp.Spec.Template.VMSize, mp.Spec.FailureDomains, supportedZones, amp.Spec.Location)
+		}
+	}
+
+	return nil
+}
+
+func inSlice(needle string, haystack []string) bool {
+	for _, supported := range haystack {
+		if needle == supported {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -2,6 +2,7 @@ package machinepool
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -69,6 +70,7 @@ func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *v1alph
 	if mp.Spec.Template.Spec.InfrastructureRef.Namespace == "" || mp.Spec.Template.Spec.InfrastructureRef.Name == "" {
 		return microerror.Maskf(azureMachinePoolNotFoundError, "MachinePool's InfrastructureRef has to be set")
 	}
+	a.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Looking for AzureMachinePool %s in namespace %s", mp.Spec.Template.Spec.InfrastructureRef.Name, mp.Spec.Template.Spec.InfrastructureRef.Namespace))
 	amp := expcapzv1alpha3.AzureMachinePool{}
 	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
 	if err != nil {

--- a/pkg/machinepool/validate_machinepool_create_test.go
+++ b/pkg/machinepool/validate_machinepool_create_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -308,6 +309,14 @@ func machinePoolRawObject(failureDomains []string) []byte {
 		},
 		Spec: capiv1alpha3.MachinePoolSpec{
 			FailureDomains: failureDomains,
+			Template: v1alpha3.MachineTemplateSpec{
+				Spec: v1alpha3.MachineSpec{
+					InfrastructureRef: v1.ObjectReference{
+						Namespace: machinePoolNamespace,
+						Name:      machinePoolName,
+					},
+				},
+			},
 		},
 	}
 	byt, _ := json.Marshal(mp)

--- a/pkg/machinepool/validate_machinepool_create_test.go
+++ b/pkg/machinepool/validate_machinepool_create_test.go
@@ -1,0 +1,315 @@
+package machinepool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	corev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/core/v1alpha1"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+)
+
+const (
+	machinePoolNamespace = "default"
+	machinePoolName      = "ab123"
+)
+
+func TestMachinePoolCreateValidate(t *testing.T) {
+	type testCase struct {
+		name         string
+		machinePool  []byte
+		vmType       string
+		allowed      bool
+		errorMatcher func(err error) bool
+	}
+
+	testCases := []testCase{
+		{
+			name:         "case 0: instance type supporting [1,2,3], requested [1]",
+			machinePool:  machinePoolRawObject([]string{"1"}),
+			vmType:       "Standard_A2_v2",
+			allowed:      true,
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 1: instance type supporting [1,2], requested [3]",
+			machinePool:  machinePoolRawObject([]string{"3"}),
+			vmType:       "Standard_A4_v2",
+			allowed:      false,
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "case 2: instance type supporting [1,2], requested [2,3]",
+			machinePool:  machinePoolRawObject([]string{"2", "3"}),
+			vmType:       "Standard_A4_v2",
+			allowed:      false,
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "case 3: instance type supporting [], requested [1]",
+			machinePool:  machinePoolRawObject([]string{"1"}),
+			vmType:       "Standard_A8_v2",
+			allowed:      false,
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "case 4: instance type supporting [], requested []",
+			machinePool:  machinePoolRawObject([]string{}),
+			vmType:       "Standard_A8_v2",
+			allowed:      true,
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 5: AzureMachinePool does not exist",
+			machinePool:  machinePoolRawObject([]string{}),
+			vmType:       "",
+			allowed:      false,
+			errorMatcher: IsAzureMachinePoolNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+			stubbedSKUs := map[string]compute.ResourceSku{
+				"Standard_A2_v2": {
+					Name: to.StringPtr("Standard_A2_v2"),
+					Capabilities: &[]compute.ResourceSkuCapabilities{
+						{
+							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
+							Value: to.StringPtr("False"),
+						},
+						{
+							Name:  to.StringPtr("vCPUs"),
+							Value: to.StringPtr("4"),
+						},
+						{
+							Name:  to.StringPtr("MemoryGB"),
+							Value: to.StringPtr("16"),
+						},
+					},
+					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+						{
+							Location: to.StringPtr("westeurope"),
+							Zones:    &[]string{"1", "2", "3"},
+						},
+					},
+				},
+				"Standard_A4_v2": {
+					Name: to.StringPtr("Standard_A4_v2"),
+					Capabilities: &[]compute.ResourceSkuCapabilities{
+						{
+							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
+							Value: to.StringPtr("False"),
+						},
+						{
+							Name:  to.StringPtr("vCPUs"),
+							Value: to.StringPtr("4"),
+						},
+						{
+							Name:  to.StringPtr("MemoryGB"),
+							Value: to.StringPtr("16"),
+						},
+					},
+					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+						{
+							Location: to.StringPtr("westeurope"),
+							Zones:    &[]string{"1", "2"},
+						},
+					},
+				},
+				"Standard_A8_v2": {
+					Name: to.StringPtr("Standard_A8_v2"),
+					Capabilities: &[]compute.ResourceSkuCapabilities{
+						{
+							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
+							Value: to.StringPtr("False"),
+						},
+						{
+							Name:  to.StringPtr("vCPUs"),
+							Value: to.StringPtr("4"),
+						},
+						{
+							Name:  to.StringPtr("MemoryGB"),
+							Value: to.StringPtr("16"),
+						},
+					},
+					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+						{
+							Location: to.StringPtr("westeurope"),
+							Zones:    &[]string{},
+						},
+					},
+				},
+			}
+			stubAPI := NewStubAPI(stubbedSKUs)
+			vmcaps, err := vmcapabilities.New(vmcapabilities.Config{
+				Azure:  stubAPI,
+				Logger: newLogger,
+			})
+			if err != nil {
+				panic(microerror.JSON(err))
+			}
+
+			scheme := runtime.NewScheme()
+			err = v1.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = corev1alpha1.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = expcapiv1alpha3.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = expcapzv1alpha3.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = capiv1alpha3.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = capzv1alpha3.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = providerv1alpha1.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+			err = releasev1alpha1.AddToScheme(scheme)
+			if err != nil {
+				panic(err)
+			}
+
+			ctrlClient := fake.NewFakeClientWithScheme(scheme)
+
+			// Create AzureMachinePool.
+			if tc.vmType != "" {
+				amp := &expcapzv1alpha3.AzureMachinePool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      machinePoolName,
+						Namespace: machinePoolNamespace,
+					},
+					Spec: expcapzv1alpha3.AzureMachinePoolSpec{
+						Location: "westeurope",
+						Template: expcapzv1alpha3.AzureMachineTemplate{
+							VMSize: tc.vmType,
+						},
+					},
+				}
+				err = ctrlClient.Create(context.Background(), amp)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			admit := &CreateValidator{
+				ctrlClient: ctrlClient,
+				logger:     newLogger,
+				vmcaps:     vmcaps,
+			}
+
+			// Run admission request to validate AzureConfig updates.
+			allowed, err := admit.Validate(context.Background(), getCreateAdmissionRequest(tc.machinePool))
+
+			// Check if the error is the expected one.
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// fall through
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("expected %#v got %#v", nil, err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("expected %#v got %#v", "error", nil)
+			case !tc.errorMatcher(err):
+				t.Fatalf("unexpected error: %#v", err)
+			}
+
+			// Check if the validation result is the expected one.
+			if tc.allowed != allowed {
+				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
+			}
+		})
+	}
+}
+
+type StubAPI struct {
+	stubbedSKUs map[string]compute.ResourceSku
+}
+
+func NewStubAPI(stubbedSKUs map[string]compute.ResourceSku) vmcapabilities.API {
+	return &StubAPI{stubbedSKUs: stubbedSKUs}
+}
+
+func (s *StubAPI) List(ctx context.Context, filter string) (map[string]compute.ResourceSku, error) {
+	return s.stubbedSKUs, nil
+}
+
+func getCreateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Resource: metav1.GroupVersionResource{
+			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
+			Resource: "azuremachinepool",
+		},
+		Operation: v1beta1.Create,
+		Object: runtime.RawExtension{
+			Raw:    newMP,
+			Object: nil,
+		},
+	}
+
+	return req
+}
+
+func machinePoolRawObject(failureDomains []string) []byte {
+	mp := capiv1alpha3.MachinePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachinePool",
+			APIVersion: "exp.cluster.x-k8s.io/v1alpha3",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machinePoolName,
+			Namespace: machinePoolNamespace,
+			Labels: map[string]string{
+				"azure-operator.giantswarm.io/version": "5.0.0",
+				"giantswarm.io/cluster":                machinePoolName,
+				"giantswarm.io/machine-pool":           machinePoolName,
+				"giantswarm.io/organization":           "giantswarm",
+				"release.giantswarm.io/version":        "13.0.0",
+			},
+		},
+		Spec: capiv1alpha3.MachinePoolSpec{
+			FailureDomains: failureDomains,
+		},
+	}
+	byt, _ := json.Marshal(mp)
+	return byt
+}

--- a/pkg/machinepool/validate_machinepool_update.go
+++ b/pkg/machinepool/validate_machinepool_update.go
@@ -1,0 +1,63 @@
+package machinepool
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	"sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+)
+
+type UpdateValidator struct {
+	logger micrologger.Logger
+}
+
+type UpdateValidatorConfig struct {
+	Logger micrologger.Logger
+}
+
+func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	admitter := &UpdateValidator{
+		logger: config.Logger,
+	}
+
+	return admitter, nil
+}
+
+func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+	machinePoolNewCR := &v1alpha3.MachinePool{}
+	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+	}
+	machinePoolOldCR := &v1alpha3.MachinePool{}
+	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, machinePoolOldCR); err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+	}
+
+	err := checkAvailabilityZonesUnchanged(ctx, machinePoolOldCR, machinePoolNewCR)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func (a *UpdateValidator) Log(keyVals ...interface{}) {
+	a.logger.Log(keyVals...)
+}
+
+func checkAvailabilityZonesUnchanged(ctx context.Context, oldMP *v1alpha3.MachinePool, newMP *v1alpha3.MachinePool) error {
+	if !reflect.DeepEqual(oldMP.Spec.FailureDomains, newMP.Spec.FailureDomains) {
+		return microerror.Maskf(invalidOperationError, "Changing FailureDomains (availability zones) is not allowed.")
+	}
+
+	return nil
+}

--- a/pkg/machinepool/validate_machinepool_update_test.go
+++ b/pkg/machinepool/validate_machinepool_update_test.go
@@ -1,0 +1,98 @@
+package machinepool
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMachinePoolUpdateValidate(t *testing.T) {
+	type testCase struct {
+		name         string
+		oldNodePool  []byte
+		newNodePool  []byte
+		allowed      bool
+		errorMatcher func(err error) bool
+	}
+
+	testCases := []testCase{
+		{
+			name:         "case 0: FailureDomains unchanged",
+			oldNodePool:  machinePoolRawObject([]string{"1", "2"}),
+			newNodePool:  machinePoolRawObject([]string{"1", "2"}),
+			allowed:      true,
+			errorMatcher: nil,
+		},
+		{
+			name:         "case 1: FailureDomains changed",
+			oldNodePool:  machinePoolRawObject([]string{"1"}),
+			newNodePool:  machinePoolRawObject([]string{"2"}),
+			allowed:      false,
+			errorMatcher: IsInvalidOperationError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+
+			admit := &UpdateValidator{
+				logger: newLogger,
+			}
+
+			// Run admission request to validate AzureConfig updates.
+			allowed, err := admit.Validate(context.Background(), getUpdateAdmissionRequest(tc.oldNodePool, tc.newNodePool))
+
+			// Check if the error is the expected one.
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// fall through
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("expected %#v got %#v", nil, err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("expected %#v got %#v", "error", nil)
+			case !tc.errorMatcher(err):
+				t.Fatalf("unexpected error: %#v", err)
+			}
+
+			// Check if the validation result is the expected one.
+			if tc.allowed != allowed {
+				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
+			}
+		})
+	}
+}
+
+func getUpdateAdmissionRequest(oldMP []byte, newMP []byte) *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Resource: metav1.GroupVersionResource{
+			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
+			Resource: "azuremachinepool",
+		},
+		Operation: v1beta1.Update,
+		Object: runtime.RawExtension{
+			Raw:    newMP,
+			Object: nil,
+		},
+		OldObject: runtime.RawExtension{
+			Raw:    oldMP,
+			Object: nil,
+		},
+	}
+
+	return req
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13878

This PR adds a new validating webhook for `MachinePool` CRs that:

- checks the availability zones (failure domains) specified in the CR are supported by the VM type in the CP location.
- checks the availability zones (failure domains) don't change