### PR TITLE
FailureDomains may be nil so deepEquals may be the wrong answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Compare `FailureDomains` field manually when updating instead of relying on `reflect.DeepEqual` which may have issues when the slice is nil or empty.
+
 ## [1.9.0] - 2020-10-21
 
 ### Added

--- a/pkg/machinepool/validate_machinepool_update.go
+++ b/pkg/machinepool/validate_machinepool_update.go
@@ -2,7 +2,7 @@ package machinepool
 
 import (
 	"context"
-	"reflect"
+	"sort"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -55,8 +55,17 @@ func (a *UpdateValidator) Log(keyVals ...interface{}) {
 }
 
 func checkAvailabilityZonesUnchanged(ctx context.Context, oldMP *v1alpha3.MachinePool, newMP *v1alpha3.MachinePool) error {
-	if !reflect.DeepEqual(oldMP.Spec.FailureDomains, newMP.Spec.FailureDomains) {
+	if len(oldMP.Spec.FailureDomains) != len(newMP.Spec.FailureDomains) {
 		return microerror.Maskf(invalidOperationError, "Changing FailureDomains (availability zones) is not allowed.")
+	}
+
+	sort.Strings(oldMP.Spec.FailureDomains)
+	sort.Strings(newMP.Spec.FailureDomains)
+
+	for i := 0; i < len(oldMP.Spec.FailureDomains); i++ {
+		if oldMP.Spec.FailureDomains[i] != newMP.Spec.FailureDomains[i] {
+			return microerror.Maskf(invalidOperationError, "Changing FailureDomains (availability zones) is not allowed.")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
In some regions there are no Failure Domains. This means that sometimes we may have a nil slice or empty slice. In that case, maybe `reflect.DeepEqual` is not the best tool. Let's compare the slices manually.