### PR TITLE
Simplify Validator interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Simplify `Validator` interface to only return `error`, dropping the `bool`.
+
 ### Added
 
 - Validate that the Organization label contains an existing Organization.

--- a/pkg/azurecluster/validate_create.go
+++ b/pkg/azurecluster/validate_create.go
@@ -46,23 +46,23 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	return v, nil
 }
 
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	azureClusterCR := &capzv1alpha3.AzureCluster{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureClusterCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, azureClusterCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = validateControlPlaneEndpoint(*azureClusterCR, a.baseDomain)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *CreateValidator) Log(keyVals ...interface{}) {

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -19,7 +19,6 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
 		azureCluster []byte
-		allowed      bool
 		errorMatcher func(err error) bool
 	}
 
@@ -27,25 +26,21 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
 			azureCluster: azureClusterRawObject("ab123", "", 0),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 1: Invalid Port",
 			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 80),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 2: Invalid Host",
 			azureCluster: azureClusterRawObject("ab123", "api.gigantic.io", 443),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Valid values",
 			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443),
-			allowed:      true,
 			errorMatcher: nil,
 		},
 	}
@@ -86,7 +81,7 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(ctx, getCreateAdmissionRequest(tc.azureCluster))
+			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.azureCluster))
 
 			// Check if the error is the expected one.
 			switch {
@@ -98,11 +93,6 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -42,33 +42,33 @@ func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) 
 	return v, nil
 }
 
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	azureClusterNewCR := &capzv1alpha3.AzureCluster{}
 	azureClusterOldCR := &capzv1alpha3.AzureCluster{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureClusterNewCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, azureClusterOldCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelUnchanged(azureClusterOldCR, azureClusterNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = validateControlPlaneEndpointUnchanged(*azureClusterOldCR, *azureClusterNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(azureClusterOldCR.Labels)
 	if err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")
 	}
 	newClusterVersion, err := semverhelper.GetSemverFromLabels(azureClusterNewCR.Labels)
 	if err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (after edit)")
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (after edit)")
 	}
 
 	return releaseversion.Validate(ctx, a.ctrlClient, oldClusterVersion, newClusterVersion)

--- a/pkg/azuremachine/validate_create.go
+++ b/pkg/azuremachine/validate_create.go
@@ -40,23 +40,23 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	return v, nil
 }
 
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	cr := &capzv1alpha3.AzureMachine{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, cr); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, cr)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkSSHKeyIsEmpty(ctx, cr)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *CreateValidator) Log(keyVals ...interface{}) {

--- a/pkg/azuremachine/validate_create_test.go
+++ b/pkg/azuremachine/validate_create_test.go
@@ -18,7 +18,6 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
 		azureMachine []byte
-		allowed      bool
 		errorMatcher func(err error) bool
 	}
 
@@ -26,13 +25,11 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 		{
 			name:         "Case 0 - empty ssh key",
 			azureMachine: azureMachineRawObject(""),
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
 			name:         "Case 1 - not empty ssh key",
 			azureMachine: azureMachineRawObject("ssh-rsa 12345 giantswarm"),
-			allowed:      false,
 			errorMatcher: IsInvalidOperationError,
 		},
 	}
@@ -72,7 +69,7 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(ctx, getCreateAdmissionRequest(tc.azureMachine))
+			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.azureMachine))
 
 			// Check if the error is the expected one.
 			switch {
@@ -84,11 +81,6 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/azuremachine/validate_update.go
+++ b/pkg/azuremachine/validate_update.go
@@ -42,33 +42,33 @@ func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) 
 	return v, nil
 }
 
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	azureMachineNewCR := &capzv1alpha3.AzureMachine{}
 	azureMachineOldCR := &capzv1alpha3.AzureMachine{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureMachineNewCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, azureMachineOldCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 
 	err := checkSSHKeyIsEmpty(ctx, azureMachineNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = generic.ValidateOrganizationLabelUnchanged(azureMachineOldCR, azureMachineNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(azureMachineOldCR.Labels)
 	if err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")
 	}
 	newClusterVersion, err := semverhelper.GetSemverFromLabels(azureMachineNewCR.Labels)
 	if err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (after edit)")
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (after edit)")
 	}
 
 	return releaseversion.Validate(ctx, a.ctrlClient, oldClusterVersion, newClusterVersion)

--- a/pkg/azuremachine/validate_update_test.go
+++ b/pkg/azuremachine/validate_update_test.go
@@ -19,7 +19,6 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 		name         string
 		oldAM        []byte
 		newAM        []byte
-		allowed      bool
 		errorMatcher func(err error) bool
 	}
 
@@ -28,14 +27,12 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 			name:         "Case 0 - empty ssh key",
 			oldAM:        azureMachineRawObject(""),
 			newAM:        azureMachineRawObject(""),
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
 			name:         "Case 1 - not empty ssh key",
 			oldAM:        azureMachineRawObject(""),
 			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm"),
-			allowed:      false,
 			errorMatcher: IsInvalidOperationError,
 		},
 	}
@@ -75,7 +72,7 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(ctx, getUpdateAdmissionRequest(tc.oldAM, tc.newAM))
+			err = admit.Validate(ctx, getUpdateAdmissionRequest(tc.oldAM, tc.newAM))
 
 			// Check if the error is the expected one.
 			switch {
@@ -87,11 +84,6 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/azuremachinepool/validate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create.go
@@ -46,43 +46,43 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	return admitter, nil
 }
 
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	azureMPNewCR := &expcapzv1alpha3.AzureMachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureMPNewCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkInstanceTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkAcceleratedNetworking(ctx, a.vmcaps, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkStorageAccountTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkSSHKeyIsEmpty(ctx, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkDataDisks(ctx, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *CreateValidator) Log(keyVals ...interface{}) {

--- a/pkg/azuremachinepool/validate_azuremachinepool_update.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update.go
@@ -39,52 +39,52 @@ func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) 
 	return admitter, nil
 }
 
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	azureMPNewCR := &expcapzv1alpha3.AzureMachinePool{}
 	azureMPOldCR := &expcapzv1alpha3.AzureMachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureMPNewCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, azureMPOldCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelUnchanged(azureMPOldCR, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkInstanceTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = a.checkAcceleratedNetworkingUpdateIsValid(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = a.checkInstanceTypeChangeIsValid(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = a.checkStorageAccountTypeUnchanged(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkSSHKeyIsEmpty(ctx, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkDataDisks(ctx, azureMPNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *UpdateValidator) checkAcceleratedNetworkingUpdateIsValid(ctx context.Context, azureMPOldCR *expcapzv1alpha3.AzureMachinePool, azureMPNewCR *expcapzv1alpha3.AzureMachinePool) error {

--- a/pkg/azureupdate/validate_azureconfig_test.go
+++ b/pkg/azureupdate/validate_azureconfig_test.go
@@ -30,7 +30,6 @@ func TestAzureConfigValidate(t *testing.T) {
 		oldVersion   string
 		newVersion   string
 		conditions   []string
-		allowed      bool
 		errorMatcher func(err error) bool
 	}{
 		{
@@ -41,7 +40,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "11.3.1",
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -52,7 +50,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "11.4.0",
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -63,7 +60,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "12.0.0",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -74,7 +70,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "11.3.0",
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -85,7 +80,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.1",
 			newVersion:   "11.4.0",
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -96,7 +90,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.1",
 			newVersion:   "",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsParsingFailed,
 		},
 		{
@@ -107,7 +100,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "",
 			newVersion:   "11.3.1",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsParsingFailed,
 		},
 		{
@@ -118,7 +110,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "11.4.0",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidReleaseError,
 		},
 		{
@@ -129,7 +120,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.0",
 			newVersion:   "11.3.1",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidReleaseError,
 		},
 		{
@@ -140,7 +130,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.3.1",
 			newVersion:   "11.3.0",
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -151,7 +140,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.0.0", // does not exist
 			newVersion:   "11.3.0", // exists
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -162,7 +150,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.4.0", // exists
 			newVersion:   "11.5.0", // does not exist
 			conditions:   []string{},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidReleaseError,
 		},
 		{
@@ -173,7 +160,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.5.0", // does not exist
 			newVersion:   "11.5.0", // does not exist
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -184,7 +170,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.4.0",
 			newVersion:   "11.4.0",
 			conditions:   []string{},
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
@@ -195,7 +180,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.4.0",
 			newVersion:   "11.4.1",
 			conditions:   []string{conditionCreating},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -206,7 +190,6 @@ func TestAzureConfigValidate(t *testing.T) {
 			oldVersion:   "11.4.0",
 			newVersion:   "11.4.1",
 			conditions:   []string{conditionUpdating},
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 	}
@@ -240,7 +223,7 @@ func TestAzureConfigValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(tc.ctx, getAdmissionRequest(tc.oldVersion, tc.newVersion, tc.conditions))
+			err = admit.Validate(tc.ctx, getAdmissionRequest(tc.oldVersion, tc.newVersion, tc.conditions))
 
 			// Check if the error is the expected one.
 			switch {
@@ -252,11 +235,6 @@ func TestAzureConfigValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/cluster/validate_create.go
+++ b/pkg/cluster/validate_create.go
@@ -46,28 +46,28 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	return v, nil
 }
 
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	clusterCR := &capiv1alpha3.Cluster{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, clusterCR); err != nil {
-		return false, microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
+		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, clusterCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = validateClusterNetwork(*clusterCR, a.baseDomain)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = validateControlPlaneEndpoint(*clusterCR, a.baseDomain)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *CreateValidator) Log(keyVals ...interface{}) {

--- a/pkg/cluster/validate_create_test.go
+++ b/pkg/cluster/validate_create_test.go
@@ -21,7 +21,6 @@ func TestClusterCreateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
 		cluster      []byte
-		allowed      bool
 		errorMatcher func(err error) bool
 	}
 
@@ -39,31 +38,26 @@ func TestClusterCreateValidate(t *testing.T) {
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
 			cluster:      clusterRawObject("ab123", clusterNetwork, "", 0),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 1: Invalid Port",
 			cluster:      clusterRawObject("ab123", clusterNetwork, "api.ab123.k8s.test.westeurope.azure.gigantic.io", 80),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 2: Invalid Host",
 			cluster:      clusterRawObject("ab123", clusterNetwork, "api.gigantic.io", 443),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Valid values",
 			cluster:      clusterRawObject("ab123", clusterNetwork, "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443),
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: ClusterNetwork null",
 			cluster:      clusterRawObject("ab123", nil, "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -82,7 +76,6 @@ func TestClusterCreateValidate(t *testing.T) {
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",
 				443,
 			),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -101,7 +94,6 @@ func TestClusterCreateValidate(t *testing.T) {
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",
 				443,
 			),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -116,7 +108,6 @@ func TestClusterCreateValidate(t *testing.T) {
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",
 				443,
 			),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
@@ -135,7 +126,6 @@ func TestClusterCreateValidate(t *testing.T) {
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",
 				443,
 			),
-			allowed:      false,
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 	}
@@ -176,7 +166,7 @@ func TestClusterCreateValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(ctx, getCreateAdmissionRequest(tc.cluster))
+			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.cluster))
 
 			// Check if the error is the expected one.
 			switch {
@@ -188,11 +178,6 @@ func TestClusterCreateValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -47,23 +47,23 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	return admitter, nil
 }
 
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	machinePoolNewCR := &v1alpha3.MachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, machinePoolNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = a.checkAvailabilityZones(ctx, machinePoolNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *CreateValidator) Log(keyVals ...interface{}) {

--- a/pkg/machinepool/validate_machinepool_update.go
+++ b/pkg/machinepool/validate_machinepool_update.go
@@ -33,27 +33,27 @@ func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) 
 	return admitter, nil
 }
 
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) (bool, error) {
+func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
 	machinePoolNewCR := &v1alpha3.MachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 	machinePoolOldCR := &v1alpha3.MachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, machinePoolOldCR); err != nil {
-		return false, microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
+		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
 	err := generic.ValidateOrganizationLabelUnchanged(machinePoolOldCR, machinePoolNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
 	err = checkAvailabilityZonesUnchanged(ctx, machinePoolOldCR, machinePoolNewCR)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return microerror.Mask(err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (a *UpdateValidator) Log(keyVals ...interface{}) {

--- a/pkg/machinepool/validate_machinepool_update_test.go
+++ b/pkg/machinepool/validate_machinepool_update_test.go
@@ -16,7 +16,6 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 		name         string
 		oldNodePool  []byte
 		newNodePool  []byte
-		allowed      bool
 		errorMatcher func(err error) bool
 	}
 
@@ -25,14 +24,12 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 			name:         "case 0: FailureDomains unchanged",
 			oldNodePool:  machinePoolRawObject([]string{"1", "2"}),
 			newNodePool:  machinePoolRawObject([]string{"1", "2"}),
-			allowed:      true,
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: FailureDomains changed",
 			oldNodePool:  machinePoolRawObject([]string{"1"}),
 			newNodePool:  machinePoolRawObject([]string{"2"}),
-			allowed:      false,
 			errorMatcher: IsInvalidOperationError,
 		},
 	}
@@ -55,7 +52,7 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 			}
 
 			// Run admission request to validate AzureConfig updates.
-			allowed, err := admit.Validate(context.Background(), getUpdateAdmissionRequest(tc.oldNodePool, tc.newNodePool))
+			err = admit.Validate(context.Background(), getUpdateAdmissionRequest(tc.oldNodePool, tc.newNodePool))
 
 			// Check if the error is the expected one.
 			switch {
@@ -67,11 +64,6 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 				t.Fatalf("expected %#v got %#v", "error", nil)
 			case !tc.errorMatcher(err):
 				t.Fatalf("unexpected error: %#v", err)
-			}
-
-			// Check if the validation result is the expected one.
-			if tc.allowed != allowed {
-				t.Fatalf("expected %v to be equal to %v", tc.allowed, allowed)
 			}
 		})
 	}

--- a/pkg/validator/handler.go
+++ b/pkg/validator/handler.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Validator interface {
-	Validate(ctx context.Context, review *v1beta1.AdmissionRequest) (bool, error)
+	Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error
 	Log(keyVals ...interface{})
 }
 
@@ -48,14 +48,14 @@ func Handler(validator Validator) http.HandlerFunc {
 			return
 		}
 
-		allowed, err := validator.Validate(request.Context(), review.Request)
+		err = validator.Validate(request.Context(), review.Request)
 		if err != nil {
 			writeResponse(validator, writer, errorResponse(review.Request.UID, microerror.Mask(err)))
 			return
 		}
 
 		writeResponse(validator, writer, &v1beta1.AdmissionResponse{
-			Allowed: allowed,
+			Allowed: true,
 			UID:     review.Request.UID,
 		})
 	}


### PR DESCRIPTION
Until now our `Validator` interface was returning `(bool, error)`. Looking at the code, it seems like every time there is an error, we `return false, err`, otherwise we `return true, nil`. So I believe it's simpler if we get rid of the boolean value and just rely on the existence of the error: if there was an error the request was not allowed, otherwise it's allowed.

WDYT?

Most of the changes were made by IntelliJ so don't worry about telling me it's an stupid idea, it was a rather quick change.