### PR TITLE
MachinePool default Spec.Replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Validate that the Organization label contains an existing Organization.
+- Set default value for `MachinePool.Spec.Replicas` to 1.
 
 ## [1.12.0] - 2020-10-27
 

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -90,7 +90,7 @@ webhooks:
       path: /mutate/machinepool/create
     caBundle: Cg==
   rules:
-    - apiGroups: ["exp.cluster.x-k8s.io/v1alpha3"]
+    - apiGroups: ["exp.cluster.x-k8s.io"]
       resources:
         - "machinepools"
       apiVersions:

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -99,6 +99,24 @@ webhooks:
         - CREATE
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
+- name: mutate.machinepools.update.{{ include "resource.default.name" . }}.giantswarm.io
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "resource.default.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /mutate/machinepool/update
+    caBundle: Cg==
+  rules:
+    - apiGroups: ["exp.cluster.x-k8s.io"]
+      resources:
+        - "machinepools"
+      apiVersions:
+        - "v1alpha3"
+      operations:
+        - UPDATE
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/main.go
+++ b/main.go
@@ -289,6 +289,17 @@ func mainError() error {
 		}
 	}
 
+	var machinePoolUpdateMutator *machinepool.UpdateMutator
+	{
+		c := machinepool.UpdateMutatorConfig{
+			Logger: newLogger,
+		}
+		machinePoolUpdateMutator, err = machinepool.NewUpdateMutator(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var machinePoolCreateValidator *machinepool.CreateValidator
 	{
 		c := machinepool.CreateValidatorConfig{
@@ -321,6 +332,7 @@ func mainError() error {
 	handler.Handle("/mutate/azurecluster/create", mutator.Handler(azureClusterCreateMutator))
 	handler.Handle("/mutate/cluster/create", mutator.Handler(clusterCreateMutator))
 	handler.Handle("/mutate/machinepool/create", mutator.Handler(machinePoolCreateMutator))
+	handler.Handle("/mutate/machinepool/update", mutator.Handler(machinePoolUpdateMutator))
 
 	// Validators.
 	handler.Handle("/validate/azureconfig/update", validator.Handler(azureConfigValidator))

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -3,7 +3,6 @@ package machinepool
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
@@ -27,19 +26,14 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	currentValue := ""
+	m.logger.LogCtx(ctx,
+		"level", "debug",
+		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, current value %s", machinePool.Spec.Replicas))
 	if machinePool.Spec.Replicas == nil {
-		currentValue = "nil"
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
-	} else {
-		currentValue = strconv.Itoa(int(*machinePool.Spec.Replicas))
 	}
-
-	m.logger.LogCtx(ctx,
-		"level", "debug",
-		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", currentValue))
 
 	return nil
 }

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -27,7 +27,7 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	var currentValue string
+	currentValue := ""
 	if machinePool.Spec.Replicas == nil {
 		currentValue = "nil"
 		const defaultReplicas = "1"

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -27,19 +27,18 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	var currentValue string
 	if machinePool.Spec.Replicas == nil {
-		currentValue = "nil"
+		m.logger.LogCtx(ctx,
+			"level", "debug",
+			"message", "setting default MachinePool.Spec.Replica value, value was nil")
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
-	} else {
-		currentValue = strconv.Itoa(int(*machinePool.Spec.Replicas))
 	}
 
 	m.logger.LogCtx(ctx,
 		"level", "debug",
-		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", currentValue))
+		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", strconv.Itoa(int(*machinePool.Spec.Replicas))))
 
 	return nil
 }

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -1,0 +1,35 @@
+package machinepool
+
+import (
+	"context"
+	"fmt"
+
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+)
+
+// setDefaultSpecValues checks if some optional field is not set, and sets
+// default values defined by upstream Cluster API.
+func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
+	var patches []mutator.PatchOperation
+
+	defaultSpecReplicas := m.setDefaultReplicaValue(ctx, machinePool)
+	if defaultSpecReplicas != nil {
+		patches = append(patches, *defaultSpecReplicas)
+	}
+
+	return patches
+}
+
+// setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
+// not, it sets its value to 1.
+func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
+	if machinePool.Spec.Replicas == nil {
+		const defaultReplicas = "1"
+		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
+		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
+	}
+
+	return nil
+}

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -11,10 +11,10 @@ import (
 
 // setDefaultSpecValues checks if some optional field is not set, and sets
 // default values defined by upstream Cluster API.
-func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
+func setDefaultSpecValues(m mutator.Mutator, ctx context.Context, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
 	var patches []mutator.PatchOperation
 
-	defaultSpecReplicas := m.setDefaultReplicaValue(ctx, machinePool)
+	defaultSpecReplicas := setDefaultReplicaValue(m, ctx, machinePool)
 	if defaultSpecReplicas != nil {
 		patches = append(patches, *defaultSpecReplicas)
 	}
@@ -24,10 +24,10 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
-func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
+func setDefaultReplicaValue(m mutator.Mutator, ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
 	if machinePool.Spec.Replicas == nil {
 		const defaultReplicas int64 = 1
-		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %d", defaultReplicas))
+		m.Log(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %d", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
 	}
 

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -27,7 +27,7 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	currentValue := ""
+	var currentValue string
 	if machinePool.Spec.Replicas == nil {
 		currentValue = "nil"
 		const defaultReplicas = "1"

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -3,6 +3,7 @@ package machinepool
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
@@ -26,14 +27,19 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	m.logger.LogCtx(ctx,
-		"level", "debug",
-		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, current value %s", machinePool.Spec.Replicas))
+	currentValue := ""
 	if machinePool.Spec.Replicas == nil {
+		currentValue = "nil"
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
+	} else {
+		currentValue = strconv.Itoa(int(*machinePool.Spec.Replicas))
 	}
+
+	m.logger.LogCtx(ctx,
+		"level", "debug",
+		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", currentValue))
 
 	return nil
 }

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -13,7 +13,6 @@ import (
 // default values defined by upstream Cluster API.
 func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
 	var patches []mutator.PatchOperation
-	m.logger.LogCtx(ctx, "level", "debug", "message", "setting default MachinePool.Spec values")
 
 	defaultSpecReplicas := m.setDefaultReplicaValue(ctx, machinePool)
 	if defaultSpecReplicas != nil {
@@ -26,9 +25,6 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	m.logger.LogCtx(ctx,
-		"level", "debug",
-		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, current value %s", machinePool.Spec.Replicas))
 	if machinePool.Spec.Replicas == nil {
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -13,6 +13,7 @@ import (
 // default values defined by upstream Cluster API.
 func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
 	var patches []mutator.PatchOperation
+	m.logger.LogCtx(ctx, "level", "debug", "message", "setting default MachinePool.Spec values")
 
 	defaultSpecReplicas := m.setDefaultReplicaValue(ctx, machinePool)
 	if defaultSpecReplicas != nil {
@@ -25,6 +26,9 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
+	m.logger.LogCtx(ctx,
+		"level", "debug",
+		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, current value %s", machinePool.Spec.Replicas))
 	if machinePool.Spec.Replicas == nil {
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -27,18 +27,19 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
+	var currentValue string
 	if machinePool.Spec.Replicas == nil {
-		m.logger.LogCtx(ctx,
-			"level", "debug",
-			"message", "setting default MachinePool.Spec.Replica value, value was nil")
+		currentValue = "nil"
 		const defaultReplicas = "1"
 		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
+	} else {
+		currentValue = strconv.Itoa(int(*machinePool.Spec.Replicas))
 	}
 
 	m.logger.LogCtx(ctx,
 		"level", "debug",
-		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", strconv.Itoa(int(*machinePool.Spec.Replicas))))
+		"message", fmt.Sprintf("setting default MachinePool.Spec.Replica value, value was %s", currentValue))
 
 	return nil
 }

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -26,8 +26,8 @@ func (m *CreateMutator) setDefaultSpecValues(ctx context.Context, machinePool *c
 // not, it sets its value to 1.
 func (m *CreateMutator) setDefaultReplicaValue(ctx context.Context, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
 	if machinePool.Spec.Replicas == nil {
-		const defaultReplicas = "1"
-		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %s", defaultReplicas))
+		const defaultReplicas int64 = 1
+		m.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %d", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
 	}
 

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -33,7 +33,6 @@ func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
 
 func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-	m.logger.LogCtx(ctx, "level", "debug", "message", "mutating MachinePool create")
 
 	if request.DryRun != nil && *request.DryRun {
 		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -33,6 +33,7 @@ func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
 
 func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
+	m.logger.LogCtx(ctx, "level", "debug", "message", "mutating MachinePool create")
 
 	if request.DryRun != nil && *request.DryRun {
 		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")

--- a/pkg/machinepool/mutate_machinepool_update.go
+++ b/pkg/machinepool/mutate_machinepool_update.go
@@ -11,27 +11,27 @@ import (
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type CreateMutator struct {
+type UpdateMutator struct {
 	logger micrologger.Logger
 }
 
-type CreateMutatorConfig struct {
+type UpdateMutatorConfig struct {
 	Logger micrologger.Logger
 }
 
-func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
+func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	m := &CreateMutator{
+	m := &UpdateMutator{
 		logger: config.Logger,
 	}
 
 	return m, nil
 }
 
-func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
 
 	if request.DryRun != nil && *request.DryRun {
@@ -44,6 +44,8 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse MachinePool CR: %v", err)
 	}
 
+	// Values for some optional spec fields could be removed in a CR update, so
+	// here we set them back again to their default values.
 	defaultSpecValues := setDefaultSpecValues(m, ctx, machinePoolCR)
 	if defaultSpecValues != nil {
 		result = append(result, defaultSpecValues...)
@@ -52,10 +54,10 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	return result, nil
 }
 
-func (m *CreateMutator) Log(keyVals ...interface{}) {
+func (m *UpdateMutator) Log(keyVals ...interface{}) {
 	m.logger.Log(keyVals...)
 }
 
-func (m *CreateMutator) Resource() string {
+func (m *UpdateMutator) Resource() string {
 	return "machinepool"
 }

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -48,6 +48,7 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 }
 
 func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
+	a.logger.LogCtx(ctx, "level", "debug", "message", "validating MachinePool create")
 	machinePoolNewCR := &v1alpha3.MachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -48,7 +48,6 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 }
 
 func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	a.logger.LogCtx(ctx, "level", "debug", "message", "validating MachinePool create")
 	machinePoolNewCR := &v1alpha3.MachinePool{}
 	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)


### PR DESCRIPTION
Setting default value for `Spec.Replicas` to 1, as specified in Cluster API.

Default value is set on:
- `MachinePool` create, when `Spec.Replicas` is not specified,
- `MachinePool` update, when `Spec.Replicas` field has been set to `nil` (so we set it back to the default value).