### PR TITLE
Create location if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate that the Organization label contains an existing Organization.
 - Set default value for `MachinePool.Spec.Replicas` to 1.
+- Set AzureMachine's and AzureCluster's location field on create if empty.
 
 ## [1.12.0] - 2020-10-27
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ func Parse() (Config, error) {
 	kingpin.Flag("tls-key-file", "File containing the private key for HTTPS").Required().StringVar(&result.KeyFile)
 	kingpin.Flag("address", "The address to listen on").Default(defaultAddress).StringVar(&result.Address)
 	kingpin.Flag("base-domain", "The base domain of the installation").Required().StringVar(&result.BaseDomain)
+	kingpin.Flag("location", "The azure region of the installation").Required().StringVar(&result.Location)
 
 	kingpin.Parse()
 	return result, nil

--- a/helm/azure-admission-controller/ci/default-values.yaml
+++ b/helm/azure-admission-controller/ci/default-values.yaml
@@ -4,6 +4,9 @@ Installation:
       Kubernetes:
         API:
           EndpointBase: k8s.test.westeurope.azure.gigantic.io
+    Provider:
+      Azure:
+        Location: westeurope
     Registry:
       Domain: quay.io
     Secret:

--- a/helm/azure-admission-controller/templates/deployment.yaml
+++ b/helm/azure-admission-controller/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
             - --base-domain={{ .Values.Installation.V1.Guest.Kubernetes.API.EndpointBase }}
+            - --location={{ .Values.Installation.V1.Provider.Azure.Location }}
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func mainError() error {
 	{
 		conf := azurecluster.CreateMutatorConfig{
 			BaseDomain: cfg.BaseDomain,
+			Location:   cfg.Location,
 			Logger:     newLogger,
 		}
 		azureClusterCreateMutator, err = azurecluster.NewCreateMutator(conf)
@@ -147,7 +148,8 @@ func mainError() error {
 	var azureMachineCreateMutator *azuremachine.CreateMutator
 	{
 		createMutatorConfig := azuremachine.CreateMutatorConfig{
-			Logger: newLogger,
+			Location: cfg.Location,
+			Logger:   newLogger,
 		}
 		azureMachineCreateMutator, err = azuremachine.NewCreateMutator(createMutatorConfig)
 		if err != nil {

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -25,22 +25,22 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
-			azureCluster: azureClusterRawObject("ab123", "", 0),
+			azureCluster: azureClusterRawObject("ab123", "", 0, "westeurope"),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 1: Invalid Port",
-			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 80),
+			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 80, "westeurope"),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 2: Invalid Host",
-			azureCluster: azureClusterRawObject("ab123", "api.gigantic.io", 443),
+			azureCluster: azureClusterRawObject("ab123", "api.gigantic.io", 443, "westeurope"),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Valid values",
-			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443),
+			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443, "westeurope"),
 			errorMatcher: nil,
 		},
 	}

--- a/pkg/azurecluster/validate_update_test.go
+++ b/pkg/azurecluster/validate_update_test.go
@@ -24,20 +24,20 @@ func TestAzureClusterUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:            "case 0: unchanged ControlPlaneEndpoint",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443),
-			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443),
+			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
 			errorMatcher:    nil,
 		},
 		{
 			name:            "case 1: host changed",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443),
-			newAzureCluster: azureClusterRawObject("ab123", "api.azure.gigantic.io", 443),
+			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			newAzureCluster: azureClusterRawObject("ab123", "api.azure.gigantic.io", 443, "westeurope"),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 		{
 			name:            "case 2: port changed",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443),
-			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 80),
+			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 80, "westeurope"),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 	}

--- a/pkg/azuremachine/common_test.go
+++ b/pkg/azuremachine/common_test.go
@@ -7,7 +7,7 @@ import (
 	providerv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 )
 
-func azureMachineRawObject(sshKey string) []byte {
+func azureMachineRawObject(sshKey string, location string) []byte {
 	mp := providerv1alpha3.AzureMachine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AzureMachine",
@@ -37,7 +37,7 @@ func azureMachineRawObject(sshKey string) []byte {
 					ThirdPartyImage: false,
 				},
 			},
-			Location: "westeurope",
+			Location: location,
 			OSDisk: providerv1alpha3.OSDisk{
 				OSType:     "Linux",
 				DiskSizeGB: 50,

--- a/pkg/azuremachine/validate_update_test.go
+++ b/pkg/azuremachine/validate_update_test.go
@@ -25,14 +25,14 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "Case 0 - empty ssh key",
-			oldAM:        azureMachineRawObject(""),
-			newAM:        azureMachineRawObject(""),
+			oldAM:        azureMachineRawObject("", "westeurope"),
+			newAM:        azureMachineRawObject("", "westeurope"),
 			errorMatcher: nil,
 		},
 		{
 			name:         "Case 1 - not empty ssh key",
-			oldAM:        azureMachineRawObject(""),
-			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm"),
+			oldAM:        azureMachineRawObject("", "westeurope"),
+			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14135

This PR ensures the `location` field is set for AzureMachine and AzureCluster.

The Mutating webhook acts on creation only and does not override existing values