### PR TITLE
Validate location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate that the Organization label contains an existing Organization.
 - Set default value for `MachinePool.Spec.Replicas` to 1.
 - Set AzureMachine's and AzureCluster's location field on create if empty.
+- Validate AzureMachine's and AzureCluster's location matches the installation location.
+- Validate AzureMachine's and AzureCluster's location never changes.
 
 ## [1.12.0] - 2020-10-27
 

--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func mainError() error {
 	{
 		c := azuremachine.CreateValidatorConfig{
 			CtrlClient: ctrlClient,
+			Location:   cfg.Location,
 			Logger:     newLogger,
 		}
 		azureMachineCreateValidator, err = azuremachine.NewCreateValidator(c)

--- a/main.go
+++ b/main.go
@@ -199,6 +199,7 @@ func mainError() error {
 		c := azurecluster.CreateValidatorConfig{
 			BaseDomain: cfg.BaseDomain,
 			CtrlClient: ctrlClient,
+			Location:   cfg.Location,
 			Logger:     newLogger,
 		}
 		azureClusterCreateValidator, err = azurecluster.NewCreateValidator(c)

--- a/pkg/azurecluster/location.go
+++ b/pkg/azurecluster/location.go
@@ -1,0 +1,24 @@
+package azurecluster
+
+import (
+	"github.com/giantswarm/microerror"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+)
+
+func validateLocation(azureCluster capzv1alpha3.AzureCluster, expectedLocation string) error {
+	if azureCluster.Spec.Location != expectedLocation {
+		return microerror.Maskf(errors.InvalidOperationError, "AzureCluster.Spec.Location can only be set to %s", expectedLocation)
+	}
+
+	return nil
+}
+
+func validateLocationUnchanged(oldAzureCluster capzv1alpha3.AzureCluster, newAzureCluster capzv1alpha3.AzureCluster) error {
+	if oldAzureCluster.Spec.Location != newAzureCluster.Spec.Location {
+		return microerror.Maskf(errors.InvalidOperationError, "AzureCluster.Spec.Location can't be changed")
+	}
+
+	return nil
+}

--- a/pkg/azurecluster/validate_create.go
+++ b/pkg/azurecluster/validate_create.go
@@ -17,12 +17,14 @@ import (
 type CreateValidator struct {
 	baseDomain string
 	ctrlClient client.Client
+	location   string
 	logger     micrologger.Logger
 }
 
 type CreateValidatorConfig struct {
 	BaseDomain string
 	CtrlClient client.Client
+	Location   string
 	Logger     micrologger.Logger
 }
 
@@ -36,10 +38,14 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.Location == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
+	}
 
 	v := &CreateValidator{
 		baseDomain: config.BaseDomain,
 		ctrlClient: config.CtrlClient,
+		location:   config.Location,
 		logger:     config.Logger,
 	}
 
@@ -58,6 +64,11 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	}
 
 	err = validateControlPlaneEndpoint(*azureClusterCR, a.baseDomain)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = validateLocation(*azureClusterCR, a.location)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -43,6 +43,11 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443, "westeurope"),
 			errorMatcher: nil,
 		},
+		{
+			name:         "case 4: Invalid region",
+			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443, "westpoland"),
+			errorMatcher: errors.IsInvalidOperationError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -77,6 +82,7 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 			admit := &CreateValidator{
 				baseDomain: "k8s.test.westeurope.azure.gigantic.io",
 				ctrlClient: ctrlClient,
+				location:   "westeurope",
 				logger:     newLogger,
 			}
 

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -62,6 +62,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
+	err = validateLocationUnchanged(*azureClusterOldCR, *azureClusterNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(azureClusterOldCR.Labels)
 	if err != nil {
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")

--- a/pkg/azurecluster/validate_update_test.go
+++ b/pkg/azurecluster/validate_update_test.go
@@ -40,6 +40,12 @@ func TestAzureClusterUpdateValidate(t *testing.T) {
 			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 80, "westeurope"),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
+		{
+			name:            "case 3: location changed",
+			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westpoland"),
+			errorMatcher:    errors.IsInvalidOperationError,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/azuremachine/location.go
+++ b/pkg/azuremachine/location.go
@@ -1,0 +1,22 @@
+package azuremachine
+
+import (
+	"github.com/giantswarm/microerror"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+)
+
+func validateLocation(azureMachine capzv1alpha3.AzureMachine, expectedLocation string) error {
+	if azureMachine.Spec.Location != expectedLocation {
+		return microerror.Maskf(invalidOperationError, "AzureCluster.Spec.Location can only be set to %s", expectedLocation)
+	}
+
+	return nil
+}
+
+func validateLocationUnchanged(old capzv1alpha3.AzureMachine, new capzv1alpha3.AzureMachine) error {
+	if old.Spec.Location != new.Spec.Location {
+		return microerror.Maskf(invalidOperationError, "AzureCluster.Spec.Location can't be changed")
+	}
+
+	return nil
+}

--- a/pkg/azuremachine/validate_create.go
+++ b/pkg/azuremachine/validate_create.go
@@ -16,11 +16,13 @@ import (
 
 type CreateValidator struct {
 	ctrlClient client.Client
+	location   string
 	logger     micrologger.Logger
 }
 
 type CreateValidatorConfig struct {
 	CtrlClient client.Client
+	Location   string
 	Logger     micrologger.Logger
 }
 
@@ -31,9 +33,13 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.Location == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
+	}
 
 	v := &CreateValidator{
 		ctrlClient: config.CtrlClient,
+		location:   config.Location,
 		logger:     config.Logger,
 	}
 
@@ -52,6 +58,11 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	}
 
 	err = checkSSHKeyIsEmpty(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = validateLocation(*cr, a.location)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azuremachine/validate_create_test.go
+++ b/pkg/azuremachine/validate_create_test.go
@@ -32,6 +32,11 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 			azureMachine: azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
+		{
+			name:         "Case 2 - invalid location",
+			azureMachine: azureMachineRawObject("", "westpoland"),
+			errorMatcher: IsInvalidOperationError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -65,6 +70,7 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 
 			admit := &CreateValidator{
 				ctrlClient: ctrlClient,
+				location:   "westeurope",
 				logger:     newLogger,
 			}
 

--- a/pkg/azuremachine/validate_update.go
+++ b/pkg/azuremachine/validate_update.go
@@ -62,6 +62,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
+	err = validateLocationUnchanged(*azureMachineOldCR, *azureMachineNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(azureMachineOldCR.Labels)
 	if err != nil {
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")

--- a/pkg/azuremachine/validate_update_test.go
+++ b/pkg/azuremachine/validate_update_test.go
@@ -35,6 +35,12 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
+		{
+			name:         "Case 2 - location changed",
+			oldAM:        azureMachineRawObject("", "westeurope"),
+			newAM:        azureMachineRawObject("", "westpoland"),
+			errorMatcher: IsInvalidOperationError,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -66,7 +72,7 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit := &CreateValidator{
+			admit := &UpdateValidator{
 				ctrlClient: ctrlClient,
 				logger:     newLogger,
 			}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14135

validate the location fields in AzureMachine and AzureCluster CRs match the installation location on create.
Validate the fact that the location fields never change on update.