### PR TITLE
Set AzureMachinePool's location field on create if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set AzureMachine's and AzureCluster's location field on create if empty.
 - Validate AzureMachine's and AzureCluster's location matches the installation location.
 - Validate AzureMachine's and AzureCluster's location never changes.
+- Set AzureMachinePool's location field on create if empty.
 
 ## [1.12.0] - 2020-10-27
 

--- a/main.go
+++ b/main.go
@@ -160,8 +160,9 @@ func mainError() error {
 	var azureMachinePoolCreateMutator *azuremachinepool.CreateMutator
 	{
 		createMutatorConfig := azuremachinepool.CreateMutatorConfig{
-			Logger: newLogger,
-			VMcaps: vmcaps,
+			Location: cfg.Location,
+			Logger:   newLogger,
+			VMcaps:   vmcaps,
 		}
 		azureMachinePoolCreateMutator, err = azuremachinepool.NewCreateMutator(createMutatorConfig)
 		if err != nil {

--- a/pkg/azuremachinepool/mutate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/mutate_azuremachinepool_create_test.go
@@ -30,7 +30,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     fmt.Sprintf("case 0: unset storage account type with premium VM"),
-			nodePool: azureMPRawObject("Standard_D4s_v3", &tr, "", desiredDataDisks),
+			nodePool: azureMPRawObject("Standard_D4s_v3", &tr, "", desiredDataDisks, "westeurope"),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -42,7 +42,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     fmt.Sprintf("case 1: unset storage account type with standard VM"),
-			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "", desiredDataDisks),
+			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "", desiredDataDisks, "westeurope"),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -54,12 +54,24 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     fmt.Sprintf("case 2: set data disks"),
-			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "Standard_LRS", nil),
+			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "Standard_LRS", nil, "westeurope"),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
 					Path:      "/spec/template/dataDisks",
 					Value:     desiredDataDisks,
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 3: set location"),
+			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "Standard_LRS", desiredDataDisks, ""),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/location",
+					Value:     "westeurope",
 				},
 			},
 			errorMatcher: nil,
@@ -132,8 +144,9 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 			}
 
 			admit := &CreateMutator{
-				logger: newLogger,
-				vmcaps: vmcaps,
+				location: "westeurope",
+				logger:   newLogger,
+				vmcaps:   vmcaps,
 			}
 
 			// Run admission request to validate AzureConfig updates.

--- a/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
@@ -40,19 +40,19 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	for i, instanceType := range unsupportedInstanceType {
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", i*3, instanceType),
-			nodePool:     azureMPRawObject(instanceType, &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			nodePool:     azureMPRawObject(instanceType, &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		})
 
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking disabled", i*3+1, instanceType),
-			nodePool:     azureMPRawObject(instanceType, &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			nodePool:     azureMPRawObject(instanceType, &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		})
 
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking nil", i*3+2, instanceType),
-			nodePool:     azureMPRawObject(instanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			nodePool:     azureMPRawObject(instanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		})
 	}
@@ -62,7 +62,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 		instanceType := "this_is_a_random_name"
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", len(testCases)-1, instanceType),
-			nodePool:     azureMPRawObject(instanceType, &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			nodePool:     azureMPRawObject(instanceType, &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: vmcapabilities.IsSkuNotFoundError,
 		})
 	}
@@ -81,7 +81,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 					DiskSizeGB: 50,
 					Lun:        to.Int32Ptr(22),
 				},
-			}),
+			}, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		})
 	}

--- a/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
@@ -40,85 +40,85 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: AcceleratedNetworking is enabled in CR and we don't change it or the instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: AcceleratedNetworking is disabled in CR and we don't change it or the instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 2: Enabled and try disabling it, keeping same instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Enabled, try updating to new instance type that supports it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[1], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[1], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Enabled, try updating to new instance type that does NOT supports it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(unsupportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(unsupportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 5: Disabled and try enabling it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 6: changed from nil to true",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 7: changed from true to nil",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 8: changed from nil to false",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 9: changed from false to nil",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 10: changed from premium to standard storage",
-			oldNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 11: changed from standard to premium storage",
-			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 12: change storage account type",
-			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
-			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesPremiumLRS), desiredDataDisks),
+			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesPremiumLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:        "case 13: change datadisks",
-			oldNodePool: azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks),
+			oldNodePool: azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			newNodePool: azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesPremiumLRS), []capzv1alpha3.DataDisk{
 				{
 					NameSuffix: "docker",
@@ -130,7 +130,7 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 					DiskSizeGB: 50,
 					Lun:        to.Int32Ptr(22),
 				},
-			}),
+			}, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
 	}
@@ -285,7 +285,7 @@ func getUpdateAdmissionRequest(oldMP []byte, newMP []byte) *v1beta1.AdmissionReq
 	return req
 }
 
-func azureMPRawObject(vmSize string, acceleratedNetworkingEnabled *bool, storageAccountType string, dataDisks []capzv1alpha3.DataDisk) []byte {
+func azureMPRawObject(vmSize string, acceleratedNetworkingEnabled *bool, storageAccountType string, dataDisks []capzv1alpha3.DataDisk, location string) []byte {
 	mp := v1alpha3.AzureMachinePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AzureMachinePool",
@@ -303,7 +303,7 @@ func azureMPRawObject(vmSize string, acceleratedNetworkingEnabled *bool, storage
 			},
 		},
 		Spec: v1alpha3.AzureMachinePoolSpec{
-			Location: "westeurope",
+			Location: location,
 			Template: v1alpha3.AzureMachineTemplate{
 				VMSize: vmSize,
 				OSDisk: capzv1alpha3.OSDisk{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14135

Ensure the `location` field is set on create for azuremachinepools.