### PR TITLE
Validate azuremachinepool location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validate that the Organization label contains an existing Organization.
 - Set default value for `MachinePool.Spec.Replicas` to 1.
-- Set AzureMachine's and AzureCluster's location field on create if empty.
-- Validate AzureMachine's and AzureCluster's location matches the installation location.
-- Validate AzureMachine's and AzureCluster's location never changes.
-- Set AzureMachinePool's location field on create if empty.
+- Set AzureMachine's, AzureCluster's, and AzureMachinePool's location field on create if empty.
+- Validate AzureMachine's, AzureCluster's, and AzureMachinePool's location matches the installation location.
+- Validate AzureMachine's, AzureCluster's, and AzureMachinePool's location never changes.
 
 ## [1.12.0] - 2020-10-27
 

--- a/main.go
+++ b/main.go
@@ -174,6 +174,7 @@ func mainError() error {
 	{
 		createValidatorConfig := azuremachinepool.CreateValidatorConfig{
 			CtrlClient: ctrlClient,
+			Location:   cfg.Location,
 			Logger:     newLogger,
 			VMcaps:     vmcaps,
 		}

--- a/pkg/azuremachine/location.go
+++ b/pkg/azuremachine/location.go
@@ -7,7 +7,7 @@ import (
 
 func validateLocation(azureMachine capzv1alpha3.AzureMachine, expectedLocation string) error {
 	if azureMachine.Spec.Location != expectedLocation {
-		return microerror.Maskf(invalidOperationError, "AzureCluster.Spec.Location can only be set to %s", expectedLocation)
+		return microerror.Maskf(invalidOperationError, "AzureMachine.Spec.Location can only be set to %s", expectedLocation)
 	}
 
 	return nil
@@ -15,7 +15,7 @@ func validateLocation(azureMachine capzv1alpha3.AzureMachine, expectedLocation s
 
 func validateLocationUnchanged(old capzv1alpha3.AzureMachine, new capzv1alpha3.AzureMachine) error {
 	if old.Spec.Location != new.Spec.Location {
-		return microerror.Maskf(invalidOperationError, "AzureCluster.Spec.Location can't be changed")
+		return microerror.Maskf(invalidOperationError, "AzureMachine.Spec.Location can't be changed")
 	}
 
 	return nil

--- a/pkg/azuremachinepool/location.go
+++ b/pkg/azuremachinepool/location.go
@@ -1,0 +1,22 @@
+package azuremachinepool
+
+import (
+	"github.com/giantswarm/microerror"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+)
+
+func checkLocation(azureMachinePool expcapzv1alpha3.AzureMachinePool, expectedLocation string) error {
+	if azureMachinePool.Spec.Location != expectedLocation {
+		return microerror.Maskf(invalidOperationError, "AzureMachinePool.Spec.Location can only be set to %s", expectedLocation)
+	}
+
+	return nil
+}
+
+func checkLocationUnchanged(old expcapzv1alpha3.AzureMachinePool, new expcapzv1alpha3.AzureMachinePool) error {
+	if old.Spec.Location != new.Spec.Location {
+		return microerror.Maskf(invalidOperationError, "AzureMachinePool.Spec.Location can't be changed")
+	}
+
+	return nil
+}

--- a/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
@@ -61,7 +61,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	{
 		instanceType := "this_is_a_random_name"
 		testCases = append(testCases, testCase{
-			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", len(testCases)-1, instanceType),
+			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", len(testCases), instanceType),
 			nodePool:     azureMPRawObject(instanceType, &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			errorMatcher: vmcapabilities.IsSkuNotFoundError,
 		})
@@ -85,6 +85,12 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 			errorMatcher: IsInvalidOperationError,
 		})
 	}
+
+	testCases = append(testCases, testCase{
+		name:         fmt.Sprintf("case %d: invalid location", len(testCases)-1),
+		nodePool:     azureMPRawObject("Standard_A2_v2", nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "eastgalicia"),
+		errorMatcher: IsInvalidOperationError,
+	})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -213,6 +219,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 
 			admit := &CreateValidator{
 				ctrlClient: ctrlClient,
+				location:   "westeurope",
 				logger:     newLogger,
 				vmcaps:     vmcaps,
 			}

--- a/pkg/azuremachinepool/validate_azuremachinepool_update.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update.go
@@ -84,6 +84,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
+	err = checkLocationUnchanged(*azureMPOldCR, *azureMPNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }
 

--- a/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
@@ -137,7 +137,7 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 			name:         "case 14: changed location",
 			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
 			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "northeastitaly"),
-			errorMatcher: nil,
+			errorMatcher: IsInvalidOperationError,
 		},
 	}
 

--- a/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
@@ -133,6 +133,12 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 			}, "westeurope"),
 			errorMatcher: IsInvalidOperationError,
 		},
+		{
+			name:         "case 14: changed location",
+			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "northeastitaly"),
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14135

This PR validates the location field in `AzureMachinePool` CRs.
It has to match the installation's location and it can't change