### PR TITLE
Validate FailureDomain for AzureMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set AzureMachine's, AzureCluster's, and AzureMachinePool's location field on create if empty.
 - Validate AzureMachine's, AzureCluster's, and AzureMachinePool's location matches the installation location.
 - Validate AzureMachine's, AzureCluster's, and AzureMachinePool's location never changes.
+- Validate FailureDomain for AzureMachine is a valid and supported one.
+- Validate FailureDomain for AzureMachine never changes.
 
 ## [1.12.0] - 2020-10-27
 

--- a/main.go
+++ b/main.go
@@ -228,6 +228,7 @@ func mainError() error {
 			CtrlClient: ctrlClient,
 			Location:   cfg.Location,
 			Logger:     newLogger,
+			VMcaps:     vmcaps,
 		}
 		azureMachineCreateValidator, err = azuremachine.NewCreateValidator(c)
 		if err != nil {

--- a/pkg/azuremachine/common_test.go
+++ b/pkg/azuremachine/common_test.go
@@ -7,7 +7,7 @@ import (
 	providerv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 )
 
-func azureMachineRawObject(sshKey string, location string) []byte {
+func azureMachineRawObject(sshKey string, location string, failureDomain *string) []byte {
 	mp := providerv1alpha3.AzureMachine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AzureMachine",
@@ -28,6 +28,7 @@ func azureMachineRawObject(sshKey string, location string) []byte {
 		},
 		Spec: providerv1alpha3.AzureMachineSpec{
 			AvailabilityZone: providerv1alpha3.AvailabilityZone{},
+			FailureDomain:    failureDomain,
 			Image: &providerv1alpha3.Image{
 				Marketplace: &providerv1alpha3.AzureMarketplaceImage{
 					Publisher:       "kinvolk",

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -1,0 +1,40 @@
+package azuremachine
+
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+)
+
+func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs []string) error {
+	// No failure domain specified.
+	if azureMachine.Spec.FailureDomain == nil {
+		return nil
+	}
+
+	for _, az := range supportedAZs {
+		if *azureMachine.Spec.FailureDomain == az {
+			// Failure Domain is valid.
+			return nil
+		}
+	}
+
+	return microerror.Maskf(invalidOperationError, "AzureMachine.Spec.FailureDomain is invalid for machine type %s in location %s. Supported AZs are %s", azureMachine.Spec.VMSize, azureMachine.Spec.Location, strings.Join(supportedAZs, ", "))
+}
+
+func validateFailureDomainUnchanged(old capzv1alpha3.AzureMachine, new capzv1alpha3.AzureMachine) error {
+	// Was unspecified, stays unspecified.
+	if old.Spec.FailureDomain == nil && new.Spec.FailureDomain == nil {
+		return nil
+	}
+
+	// Was set and got blanked, was blank and got set, was set and got changed.
+	if old.Spec.FailureDomain == nil && new.Spec.FailureDomain != nil ||
+		old.Spec.FailureDomain != nil && new.Spec.FailureDomain == nil ||
+		*old.Spec.FailureDomain != *new.Spec.FailureDomain {
+		return microerror.Maskf(invalidOperationError, "AzureMachine.Spec.FailureDomain can't be changed")
+	}
+
+	return nil
+}

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -21,7 +21,7 @@ func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs 
 		}
 	}
 
-	supportedAZsMsg := fmt.Sprintf("Location %#q supports Failure Domains %s for VM size %#q but got %#q", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize, azureMachine.Spec.FailureDomain)
+	supportedAZsMsg := fmt.Sprintf("Location %#q supports Failure Domains %s for VM size %#q but got %#q", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize, *azureMachine.Spec.FailureDomain)
 	if len(supportedAZs) == 0 {
 		supportedAZsMsg = fmt.Sprintf("Location %#q does not support specifying a Failure Domain for VM size %#q", azureMachine.Spec.Location, azureMachine.Spec.VMSize)
 	}

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -21,7 +21,7 @@ func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs 
 		}
 	}
 
-	supportedAZsMsg := fmt.Sprintf("Location %s support failure domains %s for VM size %s", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize)
+	supportedAZsMsg := fmt.Sprintf("Location %#q supports Failure Domains %s for VM size %#q but got %#q", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize, azureMachine.Spec.FailureDomain)
 	if len(supportedAZs) == 0 {
 		supportedAZsMsg = fmt.Sprintf("Location %s does not support specifying FailureDomain for VM size %s", azureMachine.Spec.Location, azureMachine.Spec.VMSize)
 	}

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -23,7 +23,7 @@ func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs 
 
 	supportedAZsMsg := fmt.Sprintf("Location %#q supports Failure Domains %s for VM size %#q but got %#q", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize, azureMachine.Spec.FailureDomain)
 	if len(supportedAZs) == 0 {
-		supportedAZsMsg = fmt.Sprintf("Location %s does not support specifying FailureDomain for VM size %s", azureMachine.Spec.Location, azureMachine.Spec.VMSize)
+		supportedAZsMsg = fmt.Sprintf("Location %#q does not support specifying a Failure Domain for VM size %#q", azureMachine.Spec.Location, azureMachine.Spec.VMSize)
 	}
 
 	return microerror.Maskf(invalidOperationError, supportedAZsMsg)

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -1,6 +1,7 @@
 package azuremachine
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/giantswarm/microerror"
@@ -20,7 +21,12 @@ func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs 
 		}
 	}
 
-	return microerror.Maskf(invalidOperationError, "AzureMachine.Spec.FailureDomain is invalid for machine type %s in location %s. Supported AZs are %s", azureMachine.Spec.VMSize, azureMachine.Spec.Location, strings.Join(supportedAZs, ", "))
+	supportedAZsMsg := fmt.Sprintf("Location %s support failure domains %s for VM size %s", azureMachine.Spec.Location, strings.Join(supportedAZs, ", "), azureMachine.Spec.VMSize)
+	if len(supportedAZs) == 0 {
+		supportedAZsMsg = fmt.Sprintf("Location %s does not support specifying FailureDomain for VM size %s", azureMachine.Spec.Location, azureMachine.Spec.VMSize)
+	}
+
+	return microerror.Maskf(invalidOperationError, supportedAZsMsg)
 }
 
 func validateFailureDomainUnchanged(old capzv1alpha3.AzureMachine, new capzv1alpha3.AzureMachine) error {

--- a/pkg/azuremachine/mutate_create_test.go
+++ b/pkg/azuremachine/mutate_create_test.go
@@ -26,7 +26,7 @@ func TestAzureMachineCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         fmt.Sprintf("case 0: Location empty"),
-			azureMachine: azureMachineRawObject("ab132", ""),
+			azureMachine: azureMachineRawObject("ab132", "", nil),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -38,7 +38,7 @@ func TestAzureMachineCreateMutate(t *testing.T) {
 		},
 		{
 			name:         fmt.Sprintf("case 1: Location has value"),
-			azureMachine: azureMachineRawObject("ab132", "westeurope"),
+			azureMachine: azureMachineRawObject("ab132", "westeurope", nil),
 			patches:      []mutator.PatchOperation{},
 			errorMatcher: nil,
 		},

--- a/pkg/azuremachine/validate_create.go
+++ b/pkg/azuremachine/validate_create.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/validator"
 )
@@ -18,12 +19,14 @@ type CreateValidator struct {
 	ctrlClient client.Client
 	location   string
 	logger     micrologger.Logger
+	vmcaps     *vmcapabilities.VMSKU
 }
 
 type CreateValidatorConfig struct {
 	CtrlClient client.Client
 	Location   string
 	Logger     micrologger.Logger
+	VMcaps     *vmcapabilities.VMSKU
 }
 
 func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
@@ -36,11 +39,15 @@ func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) 
 	if config.Location == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
 	}
+	if config.VMcaps == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
+	}
 
 	v := &CreateValidator{
 		ctrlClient: config.CtrlClient,
 		location:   config.Location,
 		logger:     config.Logger,
+		vmcaps:     config.VMcaps,
 	}
 
 	return v, nil
@@ -63,6 +70,16 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	}
 
 	err = validateLocation(*cr, a.location)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	supportedAZs, err := a.vmcaps.SupportedAZs(ctx, cr.Spec.Location, cr.Spec.VMSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = validateFailureDomain(*cr, supportedAZs)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azuremachine/validate_create_test.go
+++ b/pkg/azuremachine/validate_create_test.go
@@ -82,34 +82,6 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 			}
 
 			stubbedSKUs := map[string]compute.ResourceSku{
-				"Standard_D4_v3": {
-					Name: to.StringPtr("Standard_D4_v3"),
-					Capabilities: &[]compute.ResourceSkuCapabilities{
-						{
-							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
-							Value: to.StringPtr("False"),
-						},
-						{
-							Name:  to.StringPtr("vCPUs"),
-							Value: to.StringPtr("4"),
-						},
-						{
-							Name:  to.StringPtr("MemoryGB"),
-							Value: to.StringPtr("16"),
-						},
-						{
-							Name:  to.StringPtr("PremiumIO"),
-							Value: to.StringPtr("False"),
-						},
-					},
-					LocationInfo: &[]compute.ResourceSkuLocationInfo{
-						{
-							Zones: &[]string{
-								"1",
-							},
-						},
-					},
-				},
 				"Standard_D4s_v3": {
 					Name: to.StringPtr("Standard_D4s_v3"),
 					Capabilities: &[]compute.ResourceSkuCapabilities{

--- a/pkg/azuremachine/validate_create_test.go
+++ b/pkg/azuremachine/validate_create_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -11,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -24,18 +27,28 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "Case 0 - empty ssh key",
-			azureMachine: azureMachineRawObject("", "westeurope"),
+			azureMachine: azureMachineRawObject("", "westeurope", nil),
 			errorMatcher: nil,
 		},
 		{
 			name:         "Case 1 - not empty ssh key",
-			azureMachine: azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope"),
+			azureMachine: azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope", nil),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "Case 2 - invalid location",
-			azureMachine: azureMachineRawObject("", "westpoland"),
+			azureMachine: azureMachineRawObject("", "westpoland", nil),
 			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "Case 3 - invalid failure domain",
+			azureMachine: azureMachineRawObject("", "westeurope", to.StringPtr("2")),
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "Case 4 - valid failure domain",
+			azureMachine: azureMachineRawObject("", "westeurope", to.StringPtr("1")),
+			errorMatcher: nil,
 		},
 	}
 
@@ -68,10 +81,78 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			stubbedSKUs := map[string]compute.ResourceSku{
+				"Standard_D4_v3": {
+					Name: to.StringPtr("Standard_D4_v3"),
+					Capabilities: &[]compute.ResourceSkuCapabilities{
+						{
+							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
+							Value: to.StringPtr("False"),
+						},
+						{
+							Name:  to.StringPtr("vCPUs"),
+							Value: to.StringPtr("4"),
+						},
+						{
+							Name:  to.StringPtr("MemoryGB"),
+							Value: to.StringPtr("16"),
+						},
+						{
+							Name:  to.StringPtr("PremiumIO"),
+							Value: to.StringPtr("False"),
+						},
+					},
+					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+						{
+							Zones: &[]string{
+								"1",
+							},
+						},
+					},
+				},
+				"Standard_D4s_v3": {
+					Name: to.StringPtr("Standard_D4s_v3"),
+					Capabilities: &[]compute.ResourceSkuCapabilities{
+						{
+							Name:  to.StringPtr("AcceleratedNetworkingEnabled"),
+							Value: to.StringPtr("False"),
+						},
+						{
+							Name:  to.StringPtr("vCPUs"),
+							Value: to.StringPtr("4"),
+						},
+						{
+							Name:  to.StringPtr("MemoryGB"),
+							Value: to.StringPtr("16"),
+						},
+						{
+							Name:  to.StringPtr("PremiumIO"),
+							Value: to.StringPtr("True"),
+						},
+					},
+					LocationInfo: &[]compute.ResourceSkuLocationInfo{
+						{
+							Zones: &[]string{
+								"1",
+							},
+						},
+					},
+				},
+			}
+			stubAPI := NewStubAPI(stubbedSKUs)
+			vmcaps, err := vmcapabilities.New(vmcapabilities.Config{
+				Azure:  stubAPI,
+				Logger: newLogger,
+			})
+			if err != nil {
+				panic(microerror.JSON(err))
+			}
+
 			admit := &CreateValidator{
 				ctrlClient: ctrlClient,
 				location:   "westeurope",
 				logger:     newLogger,
+				vmcaps:     vmcaps,
 			}
 
 			// Run admission request to validate AzureConfig updates.
@@ -106,4 +187,16 @@ func getCreateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
 	}
 
 	return req
+}
+
+type StubAPI struct {
+	stubbedSKUs map[string]compute.ResourceSku
+}
+
+func NewStubAPI(stubbedSKUs map[string]compute.ResourceSku) vmcapabilities.API {
+	return &StubAPI{stubbedSKUs: stubbedSKUs}
+}
+
+func (s *StubAPI) List(ctx context.Context, filter string) (map[string]compute.ResourceSku, error) {
+	return s.stubbedSKUs, nil
 }

--- a/pkg/azuremachine/validate_update.go
+++ b/pkg/azuremachine/validate_update.go
@@ -67,6 +67,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
+	err = validateFailureDomainUnchanged(*azureMachineOldCR, *azureMachineNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(azureMachineOldCR.Labels)
 	if err != nil {
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from AzureConfig (before edit)")

--- a/pkg/azuremachine/validate_update_test.go
+++ b/pkg/azuremachine/validate_update_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -25,20 +26,26 @@ func TestAzureMachineUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "Case 0 - empty ssh key",
-			oldAM:        azureMachineRawObject("", "westeurope"),
-			newAM:        azureMachineRawObject("", "westeurope"),
+			oldAM:        azureMachineRawObject("", "westeurope", nil),
+			newAM:        azureMachineRawObject("", "westeurope", nil),
 			errorMatcher: nil,
 		},
 		{
 			name:         "Case 1 - not empty ssh key",
-			oldAM:        azureMachineRawObject("", "westeurope"),
-			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope"),
+			oldAM:        azureMachineRawObject("", "westeurope", nil),
+			newAM:        azureMachineRawObject("ssh-rsa 12345 giantswarm", "westeurope", nil),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "Case 2 - location changed",
-			oldAM:        azureMachineRawObject("", "westeurope"),
-			newAM:        azureMachineRawObject("", "westpoland"),
+			oldAM:        azureMachineRawObject("", "westeurope", nil),
+			newAM:        azureMachineRawObject("", "westpoland", nil),
+			errorMatcher: IsInvalidOperationError,
+		},
+		{
+			name:         "Case 3 - failure domain changed",
+			oldAM:        azureMachineRawObject("", "westeurope", to.StringPtr("1")),
+			newAM:        azureMachineRawObject("", "westpoland", to.StringPtr("2")),
 			errorMatcher: IsInvalidOperationError,
 		},
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14135

This PR adds validation for the FailureDomain field in AzureMachine CR.
The validator checks the (optionally) selected failureDomain is valid and supported by the vm type on the specified location.
It also checks the failureDomain never changes