### PR TITLE
Allow empty string as failureDomain for azureMachine

### DIFF
--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -10,7 +10,7 @@ import (
 
 func validateFailureDomain(azureMachine capzv1alpha3.AzureMachine, supportedAZs []string) error {
 	// No failure domain specified.
-	if azureMachine.Spec.FailureDomain == nil {
+	if azureMachine.Spec.FailureDomain == nil || *azureMachine.Spec.FailureDomain == "" {
 		return nil
 	}
 

--- a/pkg/azuremachine/validate_create_test.go
+++ b/pkg/azuremachine/validate_create_test.go
@@ -50,6 +50,16 @@ func TestAzureMachineCreateValidate(t *testing.T) {
 			azureMachine: azureMachineRawObject("", "westeurope", to.StringPtr("1")),
 			errorMatcher: nil,
 		},
+		{
+			name:         "Case 5 - empty failure domain",
+			azureMachine: azureMachineRawObject("", "westeurope", to.StringPtr("")),
+			errorMatcher: nil,
+		},
+		{
+			name:         "Case 6 - nil failure domain",
+			azureMachine: azureMachineRawObject("", "westeurope", nil),
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This PR allows to specify an empty string as failure domain.
That means the availability zone selection happens automatically.
This is what happa does (passes "" and not nil).