### PR TITLE
Relax failuredomain immutability check

### DIFF
--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -35,7 +35,7 @@ func validateFailureDomainUnchanged(old capzv1alpha3.AzureMachine, new capzv1alp
 		return nil
 	}
 
-	// Allow changing from nil to "" and from "" to nil. They are synonims.
+	// Allow changing from nil to "" and from "" to nil. They are synonyms.
 	if old.Spec.FailureDomain == nil && *new.Spec.FailureDomain == "" ||
 		*old.Spec.FailureDomain == "" && new.Spec.FailureDomain == nil {
 		return nil

--- a/pkg/azuremachine/failure_domain.go
+++ b/pkg/azuremachine/failure_domain.go
@@ -35,6 +35,12 @@ func validateFailureDomainUnchanged(old capzv1alpha3.AzureMachine, new capzv1alp
 		return nil
 	}
 
+	// Allow changing from nil to "" and from "" to nil. They are synonims.
+	if old.Spec.FailureDomain == nil && *new.Spec.FailureDomain == "" ||
+		*old.Spec.FailureDomain == "" && new.Spec.FailureDomain == nil {
+		return nil
+	}
+
 	// Was set and got blanked, was blank and got set, was set and got changed.
 	if old.Spec.FailureDomain == nil && new.Spec.FailureDomain != nil ||
 		old.Spec.FailureDomain != nil && new.Spec.FailureDomain == nil ||


### PR DESCRIPTION
This PR allows changing the `AzureMachine`'s FaultDomain field from nil to empty string and vice versa.
The meaning of the two values is identical so this makes the validation process less strict while being equally valid.