### PR TITLE
Use builder to build AzureCluster during tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate `AzureMachine`'s, `AzureCluster`'s, and `AzureMachinePool`'s `location` never changes.
 - Validate `FailureDomain` for `AzureMachine` is a valid and supported one.
 - Validate `FailureDomain` for `AzureMachine` never changes.
-- Set `release.giantswarm.io/version` label on `MachinePool`, `AzureMachinePool`, and `Spark` CRs on create if empty. 
+- Set `release.giantswarm.io/version` label on `MachinePool`, `AzureMachinePool`, and `Spark` CRs on create if empty.
+- Add builders to make it easier to write tests.
 
 ## [1.12.0] - 2020-10-27
 

--- a/internal/test/azurecluster/builder.go
+++ b/internal/test/azurecluster/builder.go
@@ -2,17 +2,16 @@ package azurecluster
 
 import (
 	"encoding/json"
-	"math/rand"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/test"
 )
 
 type BuilderOption func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func Name(name string) BuilderOption {
 	return func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster {
@@ -39,7 +38,7 @@ func ControlPlaneEndpoint(controlPlaneEndpointHost string, controlPlaneEndpointP
 }
 
 func BuildAzureCluster(opts ...BuilderOption) *capzv1alpha3.AzureCluster {
-	clusterName := generateName()
+	clusterName := test.GenerateName()
 	azureCluster := &capzv1alpha3.AzureCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AzureCluster",
@@ -79,12 +78,4 @@ func BuildAzureClusterAsJson(opts ...BuilderOption) []byte {
 	byt, _ := json.Marshal(azureCluster)
 
 	return byt
-}
-
-func generateName() string {
-	b := make([]rune, 5)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }

--- a/internal/test/azuremachinepool/builder.go
+++ b/internal/test/azuremachinepool/builder.go
@@ -1,0 +1,131 @@
+package azuremachinepool
+
+import (
+	"encoding/json"
+	"math/rand"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+type BuilderOption func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func AcceleratedNetworking(acceleratedNetworking *bool) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Spec.Template.AcceleratedNetworking = acceleratedNetworking
+		return azureMachinePool
+	}
+}
+
+func Cluster(clusterName string) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Labels[capiv1alpha3.ClusterLabelName] = clusterName
+		return azureMachinePool
+	}
+}
+
+func DataDisks(dataDisks []capzv1alpha3.DataDisk) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Spec.Template.DataDisks = dataDisks
+		return azureMachinePool
+	}
+}
+
+func Location(location string) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Spec.Location = location
+		return azureMachinePool
+	}
+}
+
+func Name(name string) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.ObjectMeta.Name = name
+		azureMachinePool.Labels[label.MachinePool] = name
+		return azureMachinePool
+	}
+}
+
+func StorageAccountType(storageAccountType compute.StorageAccountTypes) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Spec.Template.OSDisk.ManagedDisk.StorageAccountType = string(storageAccountType)
+		return azureMachinePool
+	}
+}
+
+func VMSize(vmsize string) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Spec.Template.VMSize = vmsize
+		return azureMachinePool
+	}
+}
+
+func BuildAzureMachinePool(opts ...BuilderOption) *expcapzv1alpha3.AzureMachinePool {
+	nodepoolName := generateName()
+	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodepoolName,
+			Namespace: "org-giantswarm",
+			Labels: map[string]string{
+				label.AzureOperatorVersion: "5.0.0",
+				label.Cluster:              "ab123",
+				label.MachinePool:          nodepoolName,
+				label.Organization:         "giantswarm",
+				label.ReleaseVersion:       "13.0.0",
+			},
+		},
+		Spec: expcapzv1alpha3.AzureMachinePoolSpec{
+			Location: "westeurope",
+			Template: expcapzv1alpha3.AzureMachineTemplate{
+				VMSize: "Standard_D4_v3",
+				OSDisk: capzv1alpha3.OSDisk{
+					ManagedDisk: capzv1alpha3.ManagedDisk{
+						StorageAccountType: "Standard_LRS",
+					},
+				},
+				AcceleratedNetworking: to.BoolPtr(true),
+				DataDisks: []capzv1alpha3.DataDisk{
+					{
+						NameSuffix: "docker",
+						DiskSizeGB: 100,
+						Lun:        to.Int32Ptr(21),
+					},
+					{
+						NameSuffix: "kubelet",
+						DiskSizeGB: 100,
+						Lun:        to.Int32Ptr(22),
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(azureMachinePool)
+	}
+
+	return azureMachinePool
+}
+
+func BuildAzureMachinePoolAsJson(opts ...BuilderOption) []byte {
+	azureMachinePool := BuildAzureMachinePool(opts...)
+
+	byt, _ := json.Marshal(azureMachinePool)
+
+	return byt
+}
+
+func generateName() string {
+	b := make([]rune, 5)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/internal/test/azuremachinepool/builder.go
+++ b/internal/test/azuremachinepool/builder.go
@@ -2,7 +2,6 @@ package azuremachinepool
 
 import (
 	"encoding/json"
-	"math/rand"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -11,11 +10,11 @@ import (
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/test"
 )
 
 type BuilderOption func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func AcceleratedNetworking(acceleratedNetworking *bool) BuilderOption {
 	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
@@ -68,17 +67,18 @@ func VMSize(vmsize string) BuilderOption {
 }
 
 func BuildAzureMachinePool(opts ...BuilderOption) *expcapzv1alpha3.AzureMachinePool {
-	nodepoolName := generateName()
+	nodepoolName := test.GenerateName()
 	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodepoolName,
 			Namespace: "org-giantswarm",
 			Labels: map[string]string{
-				label.AzureOperatorVersion: "5.0.0",
-				label.Cluster:              "ab123",
-				label.MachinePool:          nodepoolName,
-				label.Organization:         "giantswarm",
-				label.ReleaseVersion:       "13.0.0",
+				label.AzureOperatorVersion:    "5.0.0",
+				label.Cluster:                 "ab123",
+				capiv1alpha3.ClusterLabelName: "ab123",
+				label.MachinePool:             nodepoolName,
+				label.Organization:            "giantswarm",
+				label.ReleaseVersion:          "13.0.0",
 			},
 		},
 		Spec: expcapzv1alpha3.AzureMachinePoolSpec{
@@ -120,12 +120,4 @@ func BuildAzureMachinePoolAsJson(opts ...BuilderOption) []byte {
 	byt, _ := json.Marshal(azureMachinePool)
 
 	return byt
-}
-
-func generateName() string {
-	b := make([]rune, 5)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -1,0 +1,88 @@
+package azuremachinepool
+
+import (
+	"encoding/json"
+	"math/rand"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+)
+
+type BuilderOption func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func AzureMachinePool(azureMachinePoolName string) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.Spec.Template.Spec.InfrastructureRef.Name = azureMachinePoolName
+		return machinePool
+	}
+}
+
+func FailureDomains(failureDomains []string) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.Spec.FailureDomains = failureDomains
+		return machinePool
+	}
+}
+
+func Name(name string) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.ObjectMeta.Name = name
+		machinePool.Labels[label.MachinePool] = name
+		return machinePool
+	}
+}
+
+func BuildMachinePool(opts ...BuilderOption) *expcapiv1alpha3.MachinePool {
+	nodepoolName := generateName()
+	machinePool := &expcapiv1alpha3.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodepoolName,
+			Namespace: "org-giantswarm",
+			Labels: map[string]string{
+				label.AzureOperatorVersion: "5.0.0",
+				label.Cluster:              "ab123",
+				label.MachinePool:          nodepoolName,
+				label.Organization:         "giantswarm",
+				label.ReleaseVersion:       "13.0.0",
+			},
+		},
+		Spec: expcapiv1alpha3.MachinePoolSpec{
+			FailureDomains: []string{},
+			Template: v1alpha3.MachineTemplateSpec{
+				Spec: v1alpha3.MachineSpec{
+					InfrastructureRef: v1.ObjectReference{
+						Namespace: "org-giantswarm",
+						Name:      "ab123",
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(machinePool)
+	}
+
+	return machinePool
+}
+
+func BuildMachinePoolAsJson(opts ...BuilderOption) []byte {
+	machinePool := BuildMachinePool(opts...)
+
+	byt, _ := json.Marshal(machinePool)
+
+	return byt
+}
+
+func generateName() string {
+	b := make([]rune, 5)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -2,18 +2,18 @@ package azuremachinepool
 
 import (
 	"encoding/json"
-	"math/rand"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/test"
 )
 
 type BuilderOption func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool
-
-var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 func AzureMachinePool(azureMachinePoolName string) BuilderOption {
 	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
@@ -38,17 +38,18 @@ func Name(name string) BuilderOption {
 }
 
 func BuildMachinePool(opts ...BuilderOption) *expcapiv1alpha3.MachinePool {
-	nodepoolName := generateName()
+	nodepoolName := test.GenerateName()
 	machinePool := &expcapiv1alpha3.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodepoolName,
 			Namespace: "org-giantswarm",
 			Labels: map[string]string{
-				label.AzureOperatorVersion: "5.0.0",
-				label.Cluster:              "ab123",
-				label.MachinePool:          nodepoolName,
-				label.Organization:         "giantswarm",
-				label.ReleaseVersion:       "13.0.0",
+				label.AzureOperatorVersion:    "5.0.0",
+				label.Cluster:                 "ab123",
+				capiv1alpha3.ClusterLabelName: "ab123",
+				label.MachinePool:             nodepoolName,
+				label.Organization:            "giantswarm",
+				label.ReleaseVersion:          "13.0.0",
 			},
 		},
 		Spec: expcapiv1alpha3.MachinePoolSpec{
@@ -77,12 +78,4 @@ func BuildMachinePoolAsJson(opts ...BuilderOption) []byte {
 	byt, _ := json.Marshal(machinePool)
 
 	return byt
-}
-
-func generateName() string {
-	b := make([]rune, 5)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }

--- a/internal/test/random.go
+++ b/internal/test/random.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"math/rand"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func GenerateName() string {
+	b := make([]rune, 5)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/pkg/azurecluster/builder.go
+++ b/pkg/azurecluster/builder.go
@@ -1,0 +1,68 @@
+package azurecluster
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+type BuilderOption func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster
+
+func Location(location string) BuilderOption {
+	return func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster {
+		azureCluster.Spec.Location = location
+		return azureCluster
+	}
+}
+
+func ControlPlaneEndpoint(controlPlaneEndpointHost string, controlPlaneEndpointPort int32) BuilderOption {
+	return func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster {
+		azureCluster.Spec.ControlPlaneEndpoint.Host = controlPlaneEndpointHost
+		azureCluster.Spec.ControlPlaneEndpoint.Port = controlPlaneEndpointPort
+		return azureCluster
+	}
+}
+
+func BuildAzureCluster(clusterName string, opts ...BuilderOption) *capzv1alpha3.AzureCluster {
+	azureCluster := &capzv1alpha3.AzureCluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AzureCluster",
+			APIVersion: capzv1alpha3.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: "org-giantswarm",
+			Labels: map[string]string{
+				"azure-operator.giantswarm.io/version": "5.0.0",
+				"cluster.x-k8s.io/cluster-name":        clusterName,
+				"giantswarm.io/cluster":                clusterName,
+				"giantswarm.io/organization":           "giantswarm",
+				"release.giantswarm.io/version":        "13.0.0-alpha3",
+			},
+		},
+		Spec: capzv1alpha3.AzureClusterSpec{
+			ResourceGroup: clusterName,
+			Location:      "westeurope",
+			ControlPlaneEndpoint: v1alpha3.APIEndpoint{
+				Host: "api.gigantic.io",
+				Port: 8080,
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(azureCluster)
+	}
+
+	return azureCluster
+}
+
+func BuildAzureClusterAsJson(clusterName string, opts ...BuilderOption) []byte {
+	azureCluster := BuildAzureCluster(clusterName, opts...)
+
+	byt, _ := json.Marshal(azureCluster)
+
+	return byt
+}

--- a/pkg/azurecluster/mutate_create_test.go
+++ b/pkg/azurecluster/mutate_create_test.go
@@ -2,7 +2,6 @@ package azurecluster
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -12,8 +11,6 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
@@ -29,7 +26,7 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         fmt.Sprintf("case 0: ControlPlaneEndpoint left empty"),
-			azureCluster: azureClusterRawObject("ab132", "", 0, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("", 0)),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -46,13 +43,13 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 		},
 		{
 			name:         fmt.Sprintf("case 1: ControlPlaneEndpoint has a value"),
-			azureCluster: azureClusterRawObject("ab132", "api.giantswarm.io", 123, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("api.giantswarm.io", 123)),
 			patches:      []mutator.PatchOperation{},
 			errorMatcher: nil,
 		},
 		{
 			name:         fmt.Sprintf("case 2: Location empty"),
-			azureCluster: azureClusterRawObject("ab132", "api.giantswarm.io", 123, ""),
+			azureCluster: BuildAzureClusterAsJson("ab132", Location("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -64,7 +61,7 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 		},
 		{
 			name:         fmt.Sprintf("case 3: Location has value"),
-			azureCluster: azureClusterRawObject("ab132", "api.giantswarm.io", 123, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab132", Location("westeurope")),
 			patches:      []mutator.PatchOperation{},
 			errorMatcher: nil,
 		},
@@ -128,34 +125,4 @@ func getCreateMutateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
 	}
 
 	return req
-}
-
-func azureClusterRawObject(clusterName string, controlPlaneEndpointHost string, controlPlaneEndpointPort int32, location string) []byte {
-	mp := capzv1alpha3.AzureCluster{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AzureCluster",
-			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha3",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName,
-			Namespace: "org-giantswarm",
-			Labels: map[string]string{
-				"azure-operator.giantswarm.io/version": "5.0.0",
-				"cluster.x-k8s.io/cluster-name":        clusterName,
-				"giantswarm.io/cluster":                clusterName,
-				"giantswarm.io/organization":           "giantswarm",
-				"release.giantswarm.io/version":        "13.0.0-alpha3",
-			},
-		},
-		Spec: capzv1alpha3.AzureClusterSpec{
-			ResourceGroup: clusterName,
-			Location:      location,
-			ControlPlaneEndpoint: v1alpha3.APIEndpoint{
-				Host: controlPlaneEndpointHost,
-				Port: controlPlaneEndpointPort,
-			},
-		},
-	}
-	byt, _ := json.Marshal(mp)
-	return byt
 }

--- a/pkg/azurecluster/mutate_create_test.go
+++ b/pkg/azurecluster/mutate_create_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azurecluster"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
@@ -26,7 +27,7 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         fmt.Sprintf("case 0: ControlPlaneEndpoint left empty"),
-			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("", 0)),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab132"), builder.ControlPlaneEndpoint("", 0)),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -43,13 +44,13 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 		},
 		{
 			name:         fmt.Sprintf("case 1: ControlPlaneEndpoint has a value"),
-			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("api.giantswarm.io", 123)),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.giantswarm.io", 123)),
 			patches:      []mutator.PatchOperation{},
 			errorMatcher: nil,
 		},
 		{
 			name:         fmt.Sprintf("case 2: Location empty"),
-			azureCluster: BuildAzureClusterAsJson("ab132", Location("")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Location("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -61,7 +62,7 @@ func TestAzureClusterCreateMutate(t *testing.T) {
 		},
 		{
 			name:         fmt.Sprintf("case 3: Location has value"),
-			azureCluster: BuildAzureClusterAsJson("ab132", Location("westeurope")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Location("westeurope")),
 			patches:      []mutator.PatchOperation{},
 			errorMatcher: nil,
 		},

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -25,27 +25,27 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
-			azureCluster: azureClusterRawObject("ab123", "", 0, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab123", Location("westeurope")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 1: Invalid Port",
-			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 80, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 2: Invalid Host",
-			azureCluster: azureClusterRawObject("ab123", "api.gigantic.io", 443, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.gigantic.io", 443), Location("westeurope")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Valid values",
-			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			azureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443), Location("westeurope")),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Invalid region",
-			azureCluster: azureClusterRawObject("ab123", "api.ab123.k8s.test.westeurope.azure.gigantic.io", 443, "westpoland"),
+			azureCluster: BuildAzureClusterAsJson("ab123", Location("westpoland")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 	}

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azurecluster"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -25,27 +26,27 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
-			azureCluster: BuildAzureClusterAsJson("ab123", Location("westeurope")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab132"), builder.Location("westeurope")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 1: Invalid Port",
-			azureCluster: BuildAzureClusterAsJson("ab132", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 2: Invalid Host",
-			azureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.gigantic.io", 443), Location("westeurope")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.gigantic.io", 443), builder.Location("westeurope")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Valid values",
-			azureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443), Location("westeurope")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443), builder.Location("westeurope")),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Invalid region",
-			azureCluster: BuildAzureClusterAsJson("ab123", Location("westpoland")),
+			azureCluster: builder.BuildAzureClusterAsJson(builder.Location("westpoland")),
 			errorMatcher: errors.IsInvalidOperationError,
 		},
 	}

--- a/pkg/azurecluster/validate_update_test.go
+++ b/pkg/azurecluster/validate_update_test.go
@@ -24,26 +24,26 @@ func TestAzureClusterUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:            "case 0: unchanged ControlPlaneEndpoint",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
-			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
+			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
 			errorMatcher:    nil,
 		},
 		{
 			name:            "case 1: host changed",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
-			newAzureCluster: azureClusterRawObject("ab123", "api.azure.gigantic.io", 443, "westeurope"),
+			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.azure.gigantic.io", 443)),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 		{
 			name:            "case 2: port changed",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
-			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 80, "westeurope"),
+			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 		{
 			name:            "case 3: location changed",
-			oldAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westeurope"),
-			newAzureCluster: azureClusterRawObject("ab123", "api.ab123.test.westeurope.azure.gigantic.io", 443, "westpoland"),
+			oldAzureCluster: BuildAzureClusterAsJson("ab123", Location("westeurope")),
+			newAzureCluster: BuildAzureClusterAsJson("ab123", Location("westpoland")),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 	}

--- a/pkg/azurecluster/validate_update_test.go
+++ b/pkg/azurecluster/validate_update_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azurecluster"
 )
 
 func TestAzureClusterUpdateValidate(t *testing.T) {
@@ -24,26 +25,26 @@ func TestAzureClusterUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:            "case 0: unchanged ControlPlaneEndpoint",
-			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
-			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			oldAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
 			errorMatcher:    nil,
 		},
 		{
 			name:            "case 1: host changed",
-			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
-			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.azure.gigantic.io", 443)),
+			oldAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.azure.gigantic.io", 443)),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 		{
 			name:            "case 2: port changed",
-			oldAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
-			newAzureCluster: BuildAzureClusterAsJson("ab123", ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
+			oldAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 		{
 			name:            "case 3: location changed",
-			oldAzureCluster: BuildAzureClusterAsJson("ab123", Location("westeurope")),
-			newAzureCluster: BuildAzureClusterAsJson("ab123", Location("westpoland")),
+			oldAzureCluster: builder.BuildAzureClusterAsJson(builder.Location("westeurope")),
+			newAzureCluster: builder.BuildAzureClusterAsJson(builder.Location("westpoland")),
 			errorMatcher:    errors.IsInvalidOperationError,
 		},
 	}

--- a/pkg/azuremachinepool/mutate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/mutate_azuremachinepool_create_test.go
@@ -13,13 +13,14 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
 func TestAzureMachinePoolCreateMutate(t *testing.T) {
-	tr := true
 	type testCase struct {
 		name         string
 		nodePool     []byte
@@ -30,7 +31,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     fmt.Sprintf("case 0: unset storage account type with premium VM"),
-			nodePool: azureMPRawObject("Standard_D4s_v3", &tr, "", desiredDataDisks, "westeurope"),
+			nodePool: builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4s_v3"), builder.StorageAccountType("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -42,7 +43,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     fmt.Sprintf("case 1: unset storage account type with standard VM"),
-			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "", desiredDataDisks, "westeurope"),
+			nodePool: builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.StorageAccountType("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -54,7 +55,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     fmt.Sprintf("case 2: set data disks"),
-			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "Standard_LRS", nil, "westeurope"),
+			nodePool: builder.BuildAzureMachinePoolAsJson(builder.DataDisks([]capzv1alpha3.DataDisk{})),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -66,7 +67,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     fmt.Sprintf("case 3: set location"),
-			nodePool: azureMPRawObject("Standard_D4_v3", &tr, "Standard_LRS", desiredDataDisks, ""),
+			nodePool: builder.BuildAzureMachinePoolAsJson(builder.Location("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",

--- a/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
@@ -2,7 +2,6 @@ package azuremachinepool
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
@@ -13,14 +12,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 )
 
 func TestAzureMachinePoolUpdateValidate(t *testing.T) {
-	tr := true
-	fa := false
 	unsupportedInstanceType := []string{
 		"Standard_D16_v3",
 	}
@@ -40,86 +37,86 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: AcceleratedNetworking is enabled in CR and we don't change it or the instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: AcceleratedNetworking is disabled in CR and we don't change it or the instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 2: Enabled and try disabling it, keeping same instance type",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 3: Enabled, try updating to new instance type that supports it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[1], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[1]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Enabled, try updating to new instance type that does NOT supports it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(unsupportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(unsupportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 5: Disabled and try enabling it",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 6: changed from nil to true",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 7: changed from true to nil",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &tr, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 8: changed from nil to false",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 9: changed from false to nil",
-			oldNodePool:  azureMPRawObject(supportedInstanceType[0], &fa, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(supportedInstanceType[0], nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 10: changed from premium to standard storage",
-			oldNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(premiumStorageInstanceType)),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(standardStorageInstanceType)),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 11: changed from standard to premium storage",
-			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(standardStorageInstanceType)),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(premiumStorageInstanceType)),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 12: change storage account type",
-			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesPremiumLRS), desiredDataDisks, "westeurope"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.StorageAccountType(compute.StorageAccountTypesStandardLRS)),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.StorageAccountType(compute.StorageAccountTypesPremiumLRS)),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:        "case 13: change datadisks",
-			oldNodePool: azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool: azureMPRawObject(premiumStorageInstanceType, nil, string(compute.StorageAccountTypesPremiumLRS), []capzv1alpha3.DataDisk{
+			oldNodePool: builder.BuildAzureMachinePoolAsJson(),
+			newNodePool: builder.BuildAzureMachinePoolAsJson(builder.DataDisks([]capzv1alpha3.DataDisk{
 				{
 					NameSuffix: "docker",
 					DiskSizeGB: 30,
@@ -130,13 +127,13 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 					DiskSizeGB: 50,
 					Lun:        to.Int32Ptr(22),
 				},
-			}, "westeurope"),
+			})),
 			errorMatcher: IsInvalidOperationError,
 		},
 		{
 			name:         "case 14: changed location",
-			oldNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "westeurope"),
-			newNodePool:  azureMPRawObject(standardStorageInstanceType, nil, string(compute.StorageAccountTypesStandardLRS), desiredDataDisks, "northeastitaly"),
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("westeurope")),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("northeastitaly")),
 			errorMatcher: IsInvalidOperationError,
 		},
 	}
@@ -289,39 +286,4 @@ func getUpdateAdmissionRequest(oldMP []byte, newMP []byte) *v1beta1.AdmissionReq
 	}
 
 	return req
-}
-
-func azureMPRawObject(vmSize string, acceleratedNetworkingEnabled *bool, storageAccountType string, dataDisks []capzv1alpha3.DataDisk, location string) []byte {
-	mp := v1alpha3.AzureMachinePool{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "AzureMachinePool",
-			APIVersion: "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ab123",
-			Namespace: "default",
-			Labels: map[string]string{
-				"azure-operator.giantswarm.io/version": "5.0.0",
-				"giantswarm.io/cluster":                "ab123",
-				"giantswarm.io/machine-pool":           "ab123",
-				"giantswarm.io/organization":           "giantswarm",
-				"release.giantswarm.io/version":        "13.0.0",
-			},
-		},
-		Spec: v1alpha3.AzureMachinePoolSpec{
-			Location: location,
-			Template: v1alpha3.AzureMachineTemplate{
-				VMSize: vmSize,
-				OSDisk: capzv1alpha3.OSDisk{
-					ManagedDisk: capzv1alpha3.ManagedDisk{
-						StorageAccountType: storageAccountType,
-					},
-				},
-				AcceleratedNetworking: acceleratedNetworkingEnabled,
-				DataDisks:             dataDisks,
-			},
-		},
-	}
-	byt, _ := json.Marshal(mp)
-	return byt
 }

--- a/pkg/machinepool/validate_machinepool_update_test.go
+++ b/pkg/machinepool/validate_machinepool_update_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
 )
 
 func TestMachinePoolUpdateValidate(t *testing.T) {
@@ -22,14 +24,14 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: FailureDomains unchanged",
-			oldNodePool:  machinePoolRawObject([]string{"1", "2"}),
-			newNodePool:  machinePoolRawObject([]string{"1", "2"}),
+			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1", "2"})),
+			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1", "2"})),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: FailureDomains changed",
-			oldNodePool:  machinePoolRawObject([]string{"1"}),
-			newNodePool:  machinePoolRawObject([]string{"2"}),
+			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1"})),
+			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"2"})),
 			errorMatcher: IsInvalidOperationError,
 		},
 	}


### PR DESCRIPTION
This PR introduces a builder so that we don't have a single function that accepts all the potential parameters required to customize an `AzureCluster`. Having a single function forces us to pass all parameters every time we use it, which adds noise to the tests, i.e tests that are related to the location field need to know about the API endpoint fields.

Using the builder, each test only passes the parameters it needs to customize the `AzureCluster` object, and all other fields get a sensible default.

Before applying the pattern to all the tests I want to gather your feedback. WDYT?