### PR TITLE
Replace weird characters in Helm release name

### DIFF
--- a/helm/azure-admission-controller/templates/_helpers.tpl
+++ b/helm/azure-admission-controller/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Common labels
 {{- define "labels.common" -}}
 app: {{ include "name" . | quote }}
 {{ include "labels.selector" . }}
-app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/branch: {{ .Values.project.branch | replace "#" "-" | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/helm/azure-admission-controller/templates/_resource.tpl
+++ b/helm/azure-admission-controller/templates/_resource.tpl
@@ -7,7 +7,7 @@ characters for resource names, the stem is truncated to 47 characters to leave
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- .Release.Name | replace "." "-" | replace "_" "-" | replace "#" "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "resource.networkPolicy.name" -}}


### PR DESCRIPTION
Using the release branch for running the tests makes Helm to fail due to weird characters in the release name. This should fix it.