### PR TITLE
Fix Cluster ServiceDomain validation and defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix Cluster ServiceDomain validation and defaulting 
+
 ## [1.13.2] - 2020-11-13
 
 ## [1.13.1] - 2020-11-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Fix Cluster ServiceDomain validation and defaulting 
+- Default `Cluster.Spec.ClusterNetwork.ServiceDomain` to `cluster.local` and don't allow any other value to be set. 
 
 ## [1.13.2] - 2020-11-13
 

--- a/pkg/cluster/control_plane_endpoint.go
+++ b/pkg/cluster/control_plane_endpoint.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-func validateClusterNetwork(cluster capiv1alpha3.Cluster, baseDomain string) error {
+func validateClusterNetwork(cluster capiv1alpha3.Cluster) error {
 	if cluster.Spec.ClusterNetwork == nil {
 		return microerror.Maskf(emptyClusterNetworkError, "ClusterNetwork can't be null")
 	}
@@ -18,8 +18,8 @@ func validateClusterNetwork(cluster capiv1alpha3.Cluster, baseDomain string) err
 		return microerror.Maskf(unexpectedAPIServerPortError, "ClusterNetwork.APIServerPort can only be set to %d", key.ControlPlaneEndpointPort)
 	}
 
-	if cluster.Spec.ClusterNetwork.ServiceDomain != key.ServiceDomain(cluster.Name, baseDomain) {
-		return microerror.Maskf(unexpectedServiceDomainError, "ClusterNetwork.ServiceDomain can only be set to %s", key.ServiceDomain(cluster.Name, baseDomain))
+	if cluster.Spec.ClusterNetwork.ServiceDomain != key.ServiceDomain() {
+		return microerror.Maskf(unexpectedServiceDomainError, "ClusterNetwork.ServiceDomain can only be set to %s", key.ServiceDomain())
 	}
 
 	if cluster.Spec.ClusterNetwork.Services == nil {

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -109,7 +109,7 @@ func (m *CreateMutator) ensureClusterNetwork(ctx context.Context, clusterCR *cap
 	if clusterCR.Spec.ClusterNetwork == nil {
 		clusterNetwork := capiv1alpha3.ClusterNetwork{
 			APIServerPort: to.Int32Ptr(key.ControlPlaneEndpointPort),
-			ServiceDomain: key.ServiceDomain(clusterCR.Name, m.baseDomain),
+			ServiceDomain: key.ServiceDomain(),
 			Services: &capiv1alpha3.NetworkRanges{
 				CIDRBlocks: []string{
 					key.ClusterNetworkServiceCIDR,

--- a/pkg/cluster/mutate_create_test.go
+++ b/pkg/cluster/mutate_create_test.go
@@ -32,7 +32,7 @@ func TestClusterCreateMutate(t *testing.T) {
 
 	clusterNetwork := &v1alpha3.ClusterNetwork{
 		APIServerPort: to.Int32Ptr(443),
-		ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+		ServiceDomain: "cluster.local",
 		Services: &v1alpha3.NetworkRanges{
 			CIDRBlocks: []string{
 				"172.31.0.0/16",

--- a/pkg/cluster/validate_create.go
+++ b/pkg/cluster/validate_create.go
@@ -57,7 +57,7 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = validateClusterNetwork(*clusterCR, a.baseDomain)
+	err = validateClusterNetwork(*clusterCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/cluster/validate_create_test.go
+++ b/pkg/cluster/validate_create_test.go
@@ -25,7 +25,7 @@ func TestClusterCreateValidate(t *testing.T) {
 
 	clusterNetwork := &v1alpha3.ClusterNetwork{
 		APIServerPort: to.Int32Ptr(443),
-		ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+		ServiceDomain: "cluster.local",
 		Services: &v1alpha3.NetworkRanges{
 			CIDRBlocks: []string{
 				"172.31.0.0/16",
@@ -65,7 +65,7 @@ func TestClusterCreateValidate(t *testing.T) {
 				"ab123",
 				&v1alpha3.ClusterNetwork{
 					APIServerPort: to.Int32Ptr(80),
-					ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+					ServiceDomain: "cluster.local",
 					Services: &v1alpha3.NetworkRanges{
 						CIDRBlocks: []string{
 							"172.31.0.0/16",
@@ -103,7 +103,7 @@ func TestClusterCreateValidate(t *testing.T) {
 				"ab123",
 				&v1alpha3.ClusterNetwork{
 					APIServerPort: to.Int32Ptr(443),
-					ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+					ServiceDomain: "cluster.local",
 					Services:      nil,
 				},
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",
@@ -118,7 +118,7 @@ func TestClusterCreateValidate(t *testing.T) {
 				"ab123",
 				&v1alpha3.ClusterNetwork{
 					APIServerPort: to.Int32Ptr(443),
-					ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+					ServiceDomain: "cluster.local",
 					Services: &v1alpha3.NetworkRanges{
 						CIDRBlocks: []string{
 							"192.168.0.0/24",

--- a/pkg/cluster/validate_update_test.go
+++ b/pkg/cluster/validate_update_test.go
@@ -23,7 +23,7 @@ func TestClusterUpdateValidate(t *testing.T) {
 
 	clusterNetwork := &v1alpha3.ClusterNetwork{
 		APIServerPort: to.Int32Ptr(443),
-		ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+		ServiceDomain: "cluster.local",
 		Services: &v1alpha3.NetworkRanges{
 			CIDRBlocks: []string{
 				"172.31.0.0/16",
@@ -63,7 +63,7 @@ func TestClusterUpdateValidate(t *testing.T) {
 				"ab123",
 				&v1alpha3.ClusterNetwork{
 					APIServerPort: to.Int32Ptr(80),
-					ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+					ServiceDomain: "cluster.local",
 					Services: &v1alpha3.NetworkRanges{
 						CIDRBlocks: []string{
 							"192.168.0.0/24",
@@ -103,7 +103,7 @@ func TestClusterUpdateValidate(t *testing.T) {
 				"ab123",
 				&v1alpha3.ClusterNetwork{
 					APIServerPort: to.Int32Ptr(443),
-					ServiceDomain: "ab123.k8s.test.westeurope.azure.gigantic.io",
+					ServiceDomain: "cluster.local",
 					Services:      nil,
 				},
 				"api.ab123.k8s.test.westeurope.azure.gigantic.io",

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -11,6 +11,6 @@ func GetControlPlaneEndpointHost(clusterName string, baseDomain string) string {
 	return fmt.Sprintf("api.%s.%s", clusterName, baseDomain)
 }
 
-func ServiceDomain(clusterName string, baseDomain string) string {
-	return fmt.Sprintf("%s.%s", clusterName, baseDomain)
+func ServiceDomain() string {
+	return "cluster.local"
 }


### PR DESCRIPTION
Here https://github.com/giantswarm/azure-operator/pull/1166 we fixed how we are setting `Cluster.Spec.ClusterNetwork.ServiceDomain` in azure-operator, this is to fix the validation and defaulting.