### PR TITLE
validate organization for node pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ignore release in validation logic by setting `release.giantswarm.io/ignore` annotation on a `Release` CR.
+- Validate Organization label for `AzureMachinePool` and `MachinePool` match `Cluster`'s.
 
 ### Changed
 

--- a/internal/test/azuremachinepool/builder.go
+++ b/internal/test/azuremachinepool/builder.go
@@ -2,6 +2,7 @@ package azuremachinepool
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -40,6 +41,14 @@ func DataDisks(dataDisks []capzv1alpha3.DataDisk) BuilderOption {
 func Location(location string) BuilderOption {
 	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
 		azureMachinePool.Spec.Location = location
+		return azureMachinePool
+	}
+}
+
+func Organization(org string) BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		azureMachinePool.Labels[label.Organization] = org
+		azureMachinePool.Namespace = fmt.Sprintf("org-%s", org)
 		return azureMachinePool
 	}
 }

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -2,6 +2,7 @@ package azuremachinepool
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +34,14 @@ func Name(name string) BuilderOption {
 	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
 		machinePool.ObjectMeta.Name = name
 		machinePool.Labels[label.MachinePool] = name
+		return machinePool
+	}
+}
+
+func Organization(org string) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.Labels[label.Organization] = org
+		machinePool.Namespace = fmt.Sprintf("org-%s", org)
 		return machinePool
 	}
 }

--- a/pkg/azuremachinepool/validate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create.go
@@ -58,7 +58,7 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
-	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, azureMPNewCR)
+	err := generic.ValidateOrganizationLabelMatchesCluster(ctx, a.ctrlClient, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
@@ -8,15 +8,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -91,6 +94,12 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 		errorMatcher: IsUnexpectedLocationError,
 	})
 
+	testCases = append(testCases, testCase{
+		name:         fmt.Sprintf("case %d: invalid organization", len(testCases)-1),
+		nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.Organization("wrongorg")),
+		errorMatcher: generic.IsInvalidOrganization,
+	})
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error
@@ -116,6 +125,21 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 				Spec: securityv1alpha1.OrganizationSpec{},
 			}
 			err = ctrlClient.Create(ctx, organization)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create cluster CR.
+			cluster := &capiv1alpha3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ab123",
+					Labels: map[string]string{
+						label.Cluster:      "ab123",
+						label.Organization: "giantswarm",
+					},
+				},
+			}
+			err = ctrlClient.Create(ctx, cluster)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create_test.go
@@ -97,7 +97,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	testCases = append(testCases, testCase{
 		name:         fmt.Sprintf("case %d: invalid organization", len(testCases)-1),
 		nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.Organization("wrongorg")),
-		errorMatcher: generic.IsInvalidOrganization,
+		errorMatcher: generic.IsNodepoolOrgDoesNotMatchClusterOrg,
 	})
 
 	for _, tc := range testCases {

--- a/pkg/generic/error.go
+++ b/pkg/generic/error.go
@@ -13,13 +13,13 @@ func IsClusterNotFoundError(err error) bool {
 	return microerror.Cause(err) == clusterNotFoundError
 }
 
-var invalidOrganizationError = &microerror.Error{
-	Kind: "invalidOrganizationError",
+var nodepoolOrgDoesNotMatchClusterOrgError = &microerror.Error{
+	Kind: "nodepoolOrgDoesNotMatchClusterOrgError",
 }
 
-// IsClusterNotFoundError asserts invalidOrganizationError.
-func IsInvalidOrganization(err error) bool {
-	return microerror.Cause(err) == invalidOrganizationError
+// IsNodepoolOrgDoesNotMatchClusterOrg asserts nodepoolOrgDoesNotMatchClusterOrgError.
+func IsNodepoolOrgDoesNotMatchClusterOrg(err error) bool {
+	return microerror.Cause(err) == nodepoolOrgDoesNotMatchClusterOrgError
 }
 
 var organizationLabelNotFoundError = &microerror.Error{

--- a/pkg/generic/error.go
+++ b/pkg/generic/error.go
@@ -4,6 +4,24 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var clusterNotFoundError = &microerror.Error{
+	Kind: "clusterNotFoundError",
+}
+
+// IsClusterNotFoundError asserts clusterNotFoundError.
+func IsClusterNotFoundError(err error) bool {
+	return microerror.Cause(err) == clusterNotFoundError
+}
+
+var invalidOrganizationError = &microerror.Error{
+	Kind: "invalidOrganizationError",
+}
+
+// IsClusterNotFoundError asserts invalidOrganizationError.
+func IsInvalidOrganization(err error) bool {
+	return microerror.Cause(err) == invalidOrganizationError
+}
+
 var organizationLabelNotFoundError = &microerror.Error{
 	Kind: "organizationLabelNotFoundError",
 }

--- a/pkg/generic/validate_organization_label.go
+++ b/pkg/generic/validate_organization_label.go
@@ -80,7 +80,7 @@ func ValidateOrganizationLabelMatchesCluster(ctx context.Context, ctrlClient cli
 	}
 
 	if clusterOrg != organizationName {
-		return microerror.Maskf(invalidOrganizationError, "Organization label %#q (%#q) does not match Cluster's (%#q)", label.Organization, organizationName, clusterOrg)
+		return microerror.Maskf(nodepoolOrgDoesNotMatchClusterOrgError, "Organization label %#q (%#q) does not match Cluster's (%#q)", label.Organization, organizationName, clusterOrg)
 	}
 
 	return nil

--- a/pkg/generic/validate_organization_label.go
+++ b/pkg/generic/validate_organization_label.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/normalize"
@@ -41,6 +42,45 @@ func ValidateOrganizationLabelContainsExistingOrganization(ctx context.Context, 
 		return microerror.Maskf(organizationNotFoundError, "Organization label %#q must contain an existing organization, got %#q but didn't find any CR with name %#q", label.Organization, organizationName, normalize.AsDNSLabelName(organizationName))
 	} else if err != nil {
 		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func ValidateOrganizationLabelMatchesCluster(ctx context.Context, ctrlClient client.Client, obj metav1.Object) error {
+	organizationName, ok := obj.GetLabels()[label.Organization]
+	if !ok {
+		return microerror.Maskf(organizationLabelNotFoundError, "CR doesn't contain Organization label %#q", label.Organization)
+	}
+
+	clusterName, ok := obj.GetLabels()[label.Cluster]
+	if !ok {
+		return microerror.Maskf(clusterLabelNotFoundError, "CR doesn't contain Cluster label %#q", label.Cluster)
+	}
+
+	cluster := capiv1alpha3.Cluster{}
+	{
+		clusters := &capiv1alpha3.ClusterList{}
+		err := ctrlClient.List(ctx, clusters, client.MatchingLabels{label.Cluster: clusterName})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// We want exactly one result.
+		if len(clusters.Items) != 1 {
+			return microerror.Maskf(clusterNotFoundError, "Expected one Cluster CR with label %#q=%#q. %d found.", label.Cluster, clusterName, len(clusters.Items))
+		}
+
+		cluster = clusters.Items[0]
+	}
+
+	clusterOrg, ok := cluster.GetLabels()[label.Organization]
+	if !ok {
+		return microerror.Maskf(organizationLabelNotFoundError, "Cluster CR doesn't contain Organization label %#q", label.Organization)
+	}
+
+	if clusterOrg != organizationName {
+		return microerror.Maskf(invalidOrganizationError, "Organization label %#q (%#q) does not match Cluster's (%#q)", label.Organization, organizationName, clusterOrg)
 	}
 
 	return nil

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -53,7 +53,7 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
-	err := generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, machinePoolNewCR)
+	err := generic.ValidateOrganizationLabelMatchesCluster(ctx, a.ctrlClient, machinePoolNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/machinepool/validate_machinepool_create_test.go
+++ b/pkg/machinepool/validate_machinepool_create_test.go
@@ -7,15 +7,18 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/security/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -68,6 +71,12 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{})),
 			vmType:       "",
 			errorMatcher: IsAzureMachinePoolNotFound,
+		},
+		{
+			name:         "case 6: Wrong Organization",
+			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.Organization("wrongorg")),
+			vmType:       "",
+			errorMatcher: generic.IsInvalidOrganization,
 		},
 	}
 
@@ -195,6 +204,21 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 				Spec: securityv1alpha1.OrganizationSpec{},
 			}
 			err = ctrlClient.Create(ctx, organization)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create cluster CR.
+			cluster := &capiv1alpha3.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ab123",
+					Labels: map[string]string{
+						label.Cluster:      "ab123",
+						label.Organization: "giantswarm",
+					},
+				},
+			}
+			err = ctrlClient.Create(ctx, cluster)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/machinepool/validate_machinepool_create_test.go
+++ b/pkg/machinepool/validate_machinepool_create_test.go
@@ -76,7 +76,7 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 			name:         "case 6: Wrong Organization",
 			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.Organization("wrongorg")),
 			vmType:       "",
-			errorMatcher: generic.IsInvalidOrganization,
+			errorMatcher: generic.IsNodepoolOrgDoesNotMatchClusterOrg,
 		},
 	}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14519

this PR validates that machinepool and azuremachinepools CRs have the right organization (has to match their Cluster's) on create.