### PR TITLE
Bump cert-manager apiversion to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update cert apiVersion to v1.
+
 ## [1.16.0] - 2020-12-15
 
 ### Added

--- a/helm/azure-admission-controller/templates/certificate.yaml
+++ b/helm/azure-admission-controller/templates/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "resource.default.name"  . }}-certificates

--- a/local_dev/clusterissuer.yml
+++ b/local_dev/clusterissuer.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-giantswarm


### PR DESCRIPTION
We need to update cert manager to v1 otherwise we might also run into issues like kiam
see giantswarm/kiam-app#63

CPs have cert-manager-app-2.3.0 (cert-manager v1.0.2), so GA APIs can be used.