### PR TITLE
Ignore Deprecated releases during upgrade validations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update cert apiVersion to v1.
+- Ignore Deprecated releases during upgrade validations.
 
 ## [1.16.0] - 2020-12-15
 

--- a/internal/releaseversion/releaseversion.go
+++ b/internal/releaseversion/releaseversion.go
@@ -2,7 +2,6 @@ package releaseversion
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/blang/semver"
@@ -44,10 +43,6 @@ func Validate(ctx context.Context, ctrlCLient client.Client, oldVersion semver.V
 
 	// Remove alpha and ignored releases from remaining validations logic.
 	availableReleases = filterOutAlphaAndIgnoredAndDeprecatedReleases(availableReleases)
-
-	for _, r := range availableReleases {
-		fmt.Println(r.Version)
-	}
 
 	if oldVersion.Major != newVersion.Major || oldVersion.Minor != newVersion.Minor {
 		// The major or minor version is changed. We support this only for sequential minor releases (no skip allowed).

--- a/internal/releaseversion/releaseversion.go
+++ b/internal/releaseversion/releaseversion.go
@@ -50,8 +50,6 @@ func Validate(ctx context.Context, ctrlCLient client.Client, oldVersion semver.V
 			if release.Version.EQ(oldVersion) || release.Version.EQ(newVersion) {
 				continue
 			}
-			// Special case: we allow jumping to the next Major release from the very latest patch release of the previous major.
-
 			// Look for a release with higher major or higher minor than the oldVersion and is LT the newVersion
 			if release.Version.GT(oldVersion) && release.Version.LT(newVersion) &&
 				(oldVersion.Major != release.Version.Major || oldVersion.Minor != release.Version.Minor) &&

--- a/internal/releaseversion/releaseversion.go
+++ b/internal/releaseversion/releaseversion.go
@@ -31,6 +31,11 @@ func Validate(ctx context.Context, ctrlCLient client.Client, oldVersion semver.V
 		return microerror.Maskf(releaseNotFoundError, "release %s was not found in this installation", newVersion)
 	}
 
+	// Skip validations for ignored releases.
+	if isOldOrNewReleaseIgnored(availableReleases, oldVersion, newVersion) {
+		return nil
+	}
+
 	// Downgrades are not allowed.
 	if newVersion.LT(oldVersion) {
 		return microerror.Maskf(downgradingIsNotAllowedError, "downgrading is not allowed (attempted to downgrade from %s to %s)", oldVersion, newVersion)

--- a/pkg/azureupdate/common_test.go
+++ b/pkg/azureupdate/common_test.go
@@ -3,18 +3,31 @@ package azureupdate
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	releasev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ensureReleases(ctrlClient client.Client, releases []string) error {
+type ReleaseWithState struct {
+	Version string
+	Ignored bool
+	State   releasev1alpha1.ReleaseState
+}
+
+func ensureReleases(ctrlClient client.Client, releases []ReleaseWithState) error {
 	// Create Releases.
 	for _, release := range releases {
 		req := &releasev1alpha1.Release{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("v%s", release),
+				Name: fmt.Sprintf("v%s", release.Version),
+				Annotations: map[string]string{
+					"release.giantswarm.io/ignore": strconv.FormatBool(release.Ignored),
+				},
+			},
+			Spec: releasev1alpha1.ReleaseSpec{
+				State: release.State,
 			},
 		}
 

--- a/pkg/azureupdate/validate_azureclusterconfig_test.go
+++ b/pkg/azureupdate/validate_azureclusterconfig_test.go
@@ -26,12 +26,37 @@ import (
 )
 
 func TestAzureClusterConfigValidate(t *testing.T) {
-	releases := []string{"11.3.0", "11.3.1", "11.4.0", "12.0.0", "12.0.1", "12.1.0"}
+	releases := []ReleaseWithState{
+		{
+			Version: "11.3.0",
+			State:   releasev1alpha1.StateDeprecated,
+		},
+		{
+			Version: "11.3.1",
+			State:   releasev1alpha1.StateActive,
+		},
+		{
+			Version: "11.4.0",
+			State:   releasev1alpha1.StateActive,
+		},
+		{
+			Version: "12.0.0",
+			State:   releasev1alpha1.StateActive,
+		},
+		{
+			Version: "12.0.1",
+			State:   releasev1alpha1.StateDeprecated,
+		},
+		{
+			Version: "12.1.0",
+			State:   releasev1alpha1.StateActive,
+		},
+	}
 
 	testCases := []struct {
 		name         string
 		ctx          context.Context
-		releases     []string
+		releases     []ReleaseWithState
 		oldVersion   string
 		newVersion   string
 		errorMatcher func(err error) bool
@@ -103,7 +128,7 @@ func TestAzureClusterConfigValidate(t *testing.T) {
 			name: "case 7",
 			ctx:  context.Background(),
 
-			releases:     []string{"invalid"},
+			releases:     []ReleaseWithState{{Version: "invalid", State: releasev1alpha1.StateActive}},
 			oldVersion:   "11.3.0",
 			newVersion:   "11.4.0",
 			errorMatcher: errors.IsInvalidReleaseError,
@@ -112,7 +137,7 @@ func TestAzureClusterConfigValidate(t *testing.T) {
 			name: "case 8",
 			ctx:  context.Background(),
 
-			releases:     []string{"invalid"},
+			releases:     []ReleaseWithState{{Version: "invalid", State: releasev1alpha1.StateActive}},
 			oldVersion:   "11.3.0",
 			newVersion:   "11.3.1",
 			errorMatcher: errors.IsInvalidReleaseError,

--- a/pkg/azureupdate/validate_azureconfig_test.go
+++ b/pkg/azureupdate/validate_azureconfig_test.go
@@ -3,6 +3,8 @@ package azureupdate
 import (
 	"context"
 	"encoding/json"
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"testing"
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
@@ -12,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/internal/releaseversion"
 )
 
@@ -146,12 +147,50 @@ func TestMasterCIDR(t *testing.T) {
 }
 
 func TestAzureConfigValidate(t *testing.T) {
-	releases := []string{"11.3.0", "11.3.1", "11.4.0", "12.0.0"}
+	releases := []ReleaseWithState{
+		{
+			Version: "11.3.0",
+			State:   v1alpha1.StateDeprecated,
+		},
+		{
+			Version: "11.3.1",
+			State:   v1alpha1.StateActive,
+		},
+		{
+			Version: "11.4.0",
+			State:   v1alpha1.StateActive,
+		},
+		{
+			Version: "12.0.0",
+			State:   v1alpha1.StateActive,
+		},
+		{
+			Version: "12.1.1",
+			State:   v1alpha1.StateDeprecated,
+		},
+		{
+			Version: "12.1.2",
+			State:   v1alpha1.StateActive,
+		},
+		{
+			Version: "13.0.1",
+			State:   v1alpha1.StateDeprecated,
+		},
+		{
+			Version: "13.0.2",
+			Ignored: true,
+			State:   v1alpha1.StateActive,
+		},
+		{
+			Version: "13.1.0",
+			State:   v1alpha1.StateActive,
+		},
+	}
 
 	testCases := []struct {
 		name         string
 		ctx          context.Context
-		releases     []string
+		releases     []ReleaseWithState
 		oldVersion   string
 		newVersion   string
 		errorMatcher func(err error) bool
@@ -223,7 +262,7 @@ func TestAzureConfigValidate(t *testing.T) {
 			name: "case 7",
 			ctx:  context.Background(),
 
-			releases:     []string{"invalid"},
+			releases:     []ReleaseWithState{{Version: "invalid", State: v1alpha1.StateActive}},
 			oldVersion:   "11.3.0",
 			newVersion:   "11.4.0",
 			errorMatcher: errors.IsInvalidReleaseError,
@@ -232,7 +271,7 @@ func TestAzureConfigValidate(t *testing.T) {
 			name: "case 8",
 			ctx:  context.Background(),
 
-			releases:     []string{"invalid"},
+			releases:     []ReleaseWithState{{Version: "invalid", State: v1alpha1.StateActive}},
 			oldVersion:   "11.3.0",
 			newVersion:   "11.3.1",
 			errorMatcher: errors.IsInvalidReleaseError,
@@ -280,6 +319,43 @@ func TestAzureConfigValidate(t *testing.T) {
 			releases:     releases,
 			oldVersion:   "11.4.0",
 			newVersion:   "11.4.0",
+			errorMatcher: nil,
+		},
+		{
+			name: "case 14",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "12.1.2",
+			newVersion:   "13.1.0",
+			errorMatcher: nil,
+		},
+		{
+			name: "case 15",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "12.0.0",
+			newVersion:   "13.1.0",
+			errorMatcher: releaseversion.IsSkippingReleaseError,
+		},
+		{
+			name: "case 16",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "12.1.1",
+			newVersion:   "13.1.0",
+			errorMatcher: nil,
+		},
+
+		{
+			name: "case 17",
+			ctx:  context.Background(),
+
+			releases:     releases,
+			oldVersion:   "12.1.2",
+			newVersion:   "13.1.0",
 			errorMatcher: nil,
 		},
 	}

--- a/pkg/azureupdate/validate_azureconfig_test.go
+++ b/pkg/azureupdate/validate_azureconfig_test.go
@@ -3,17 +3,18 @@ package azureupdate
 import (
 	"context"
 	"encoding/json"
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"testing"
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/internal/releaseversion"
 )
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15142

This PR ignores deprecated releases when checking if an upgrade path is valid or not.