### PR TITLE
Ensure autoscaler min and max annotations are present 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure autoscaler min and max annotations are present when creating or updating a `Machinepool`.
+
 ## [1.17.0] - 2021-01-14
 
 ### Changed

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -3,6 +3,7 @@ package azuremachinepool
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	v1 "k8s.io/api/core/v1"
@@ -49,6 +50,8 @@ func Organization(org string) BuilderOption {
 func Replicas(replicas int32) BuilderOption {
 	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
 		machinePool.Spec.Replicas = &replicas
+		machinePool.Annotations[annotation.NodePoolMinSize] = fmt.Sprintf("%d", replicas)
+		machinePool.Annotations[annotation.NodePoolMaxSize] = fmt.Sprintf("%d", replicas)
 		return machinePool
 	}
 }

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -3,7 +3,7 @@ package azuremachinepool
 import (
 	"encoding/json"
 	"fmt"
-
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,12 +46,30 @@ func Organization(org string) BuilderOption {
 	}
 }
 
+func Replicas(replicas int32) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.Spec.Replicas = &replicas
+		return machinePool
+	}
+}
+
+func Annotation(name, val string) BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		machinePool.Annotations[name] = val
+		return machinePool
+	}
+}
+
 func BuildMachinePool(opts ...BuilderOption) *expcapiv1alpha3.MachinePool {
 	nodepoolName := test.GenerateName()
 	machinePool := &expcapiv1alpha3.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nodepoolName,
 			Namespace: "org-giantswarm",
+			Annotations: map[string]string{
+				annotation.NodePoolMinSize: "1",
+				annotation.NodePoolMaxSize: "1",
+			},
 			Labels: map[string]string{
 				label.AzureOperatorVersion:    "5.0.0",
 				label.Cluster:                 "ab123",

--- a/pkg/machinepool/autoscaling.go
+++ b/pkg/machinepool/autoscaling.go
@@ -18,8 +18,8 @@ func escapeJSONPatchString(input string) string {
 	return input
 }
 
-// setDefaultSpecValues checks if some optional field is not set, and sets
-// default values defined by upstream Cluster API.
+// ensureAutoscalingAnnotations ensures the custom annotations used to determine the min and max replicas for
+// the cluster autoscaler are set in the Machinepool CR.
 func ensureAutoscalingAnnotations(m mutator.Mutator, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
 	var patches []mutator.PatchOperation
 

--- a/pkg/machinepool/autoscaling.go
+++ b/pkg/machinepool/autoscaling.go
@@ -24,7 +24,7 @@ func ensureAutoscalingAnnotations(m mutator.Mutator, machinePool *capiexp.Machin
 	var patches []mutator.PatchOperation
 
 	// The replicas field could not be set, we default to 1.
-	clusterReplicas := int32(1)
+	clusterReplicas := int32(defaultReplicas)
 	if machinePool.Spec.Replicas != nil {
 		clusterReplicas = *machinePool.Spec.Replicas
 	}

--- a/pkg/machinepool/autoscaling.go
+++ b/pkg/machinepool/autoscaling.go
@@ -2,10 +2,12 @@ package machinepool
 
 import (
 	"fmt"
-	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
-	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"strings"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
 // Ensure the needed escapes are in place. See https://tools.ietf.org/html/rfc6901#section-3 .

--- a/pkg/machinepool/autoscaling.go
+++ b/pkg/machinepool/autoscaling.go
@@ -33,14 +33,14 @@ func ensureAutoscalingAnnotations(m mutator.Mutator, machinePool *capiexp.Machin
 	currentMin := clusterReplicas
 	if machinePool.Annotations[annotation.NodePoolMinSize] == "" {
 		m.Log("level", "debug", "message", fmt.Sprintf("setting MachinePool Annotation %s to %d", annotation.NodePoolMinSize, clusterReplicas))
-		patches = append(patches, *mutator.PatchAdd(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMinSize)), clusterReplicas))
+		patches = append(patches, *mutator.PatchAdd(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMinSize)), fmt.Sprintf("%d", clusterReplicas)))
 	} else {
 		// Parse current value of min Size.
 		min, err := strconv.Atoi(machinePool.Annotations[annotation.NodePoolMinSize])
 		if err != nil || min < 1 {
 			// Invalid annotation value, set it to the default.
 			m.Log("level", "debug", "message", fmt.Sprintf("setting MachinePool Annotation %s to %d", annotation.NodePoolMinSize, clusterReplicas))
-			patches = append(patches, mutator.PatchReplace(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMinSize)), clusterReplicas))
+			patches = append(patches, mutator.PatchReplace(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMinSize)), fmt.Sprintf("%d", clusterReplicas)))
 			currentMin = clusterReplicas
 		} else {
 			currentMin = int32(min)
@@ -50,13 +50,13 @@ func ensureAutoscalingAnnotations(m mutator.Mutator, machinePool *capiexp.Machin
 	if machinePool.Annotations[annotation.NodePoolMaxSize] == "" {
 		// By default set the max same value as the min.
 		m.Log("level", "debug", "message", fmt.Sprintf("setting MachinePool Annotation %s to %d", annotation.NodePoolMaxSize, currentMin))
-		patches = append(patches, *mutator.PatchAdd(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMaxSize)), currentMin))
+		patches = append(patches, *mutator.PatchAdd(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMaxSize)), fmt.Sprintf("%d", currentMin)))
 	} else {
 		// Check current value is valid.
 		max, err := strconv.Atoi(machinePool.Annotations[annotation.NodePoolMaxSize])
 		if err != nil || int32(max) < currentMin {
 			m.Log("level", "debug", "message", fmt.Sprintf("setting MachinePool Annotation %s to %d", annotation.NodePoolMaxSize, currentMin))
-			patches = append(patches, mutator.PatchReplace(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMaxSize)), currentMin))
+			patches = append(patches, mutator.PatchReplace(fmt.Sprintf("/metadata/annotations/%s", escapeJSONPatchString(annotation.NodePoolMaxSize)), fmt.Sprintf("%d", currentMin)))
 		}
 	}
 

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -8,6 +8,8 @@ import (
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
+const defaultReplicas int64 = 1
+
 // setDefaultSpecValues checks if some optional field is not set, and sets
 // default values defined by upstream Cluster API.
 func setDefaultSpecValues(m mutator.Mutator, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
@@ -25,7 +27,6 @@ func setDefaultSpecValues(m mutator.Mutator, machinePool *capiexp.MachinePool) [
 // not, it sets its value to 1.
 func setDefaultReplicaValue(m mutator.Mutator, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
 	if machinePool.Spec.Replicas == nil {
-		const defaultReplicas int64 = 1
 		m.Log("level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %d", defaultReplicas))
 		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
 	}

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -73,6 +73,11 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
+	patches := ensureAutoscalingAnnotations(m, machinePoolCR)
+	if patches != nil {
+		result = append(result, patches...)
+	}
+
 	return result, nil
 }
 

--- a/pkg/machinepool/mutate_machinepool_create_test.go
+++ b/pkg/machinepool/mutate_machinepool_create_test.go
@@ -48,7 +48,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -60,7 +60,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -72,12 +72,12 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -94,12 +94,12 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 			},
 			errorMatcher: nil,

--- a/pkg/machinepool/mutate_machinepool_create_test.go
+++ b/pkg/machinepool/mutate_machinepool_create_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
@@ -36,6 +37,69 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/replicas",
 					Value:     int64(1),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 1: set min replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 2: set max replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 3: set min and max replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(7),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 4: set min and max replicas annotation when replicas field is not set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     int64(1),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(1),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(1),
 				},
 			},
 			errorMatcher: nil,

--- a/pkg/machinepool/mutate_machinepool_update.go
+++ b/pkg/machinepool/mutate_machinepool_update.go
@@ -2,6 +2,7 @@ package machinepool
 
 import (
 	"context"
+
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"

--- a/pkg/machinepool/mutate_machinepool_update.go
+++ b/pkg/machinepool/mutate_machinepool_update.go
@@ -2,7 +2,6 @@ package machinepool
 
 import (
 	"context"
-
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
@@ -49,6 +48,12 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	defaultSpecValues := setDefaultSpecValues(m, machinePoolCR)
 	if defaultSpecValues != nil {
 		result = append(result, defaultSpecValues...)
+	}
+
+	// Ensure autoscaling annotations are set.
+	patch := ensureAutoscalingAnnotations(m, machinePoolCR)
+	if patch != nil {
+		result = append(result, patch...)
 	}
 
 	return result, nil

--- a/pkg/machinepool/mutate_machinepool_update_test.go
+++ b/pkg/machinepool/mutate_machinepool_update_test.go
@@ -104,6 +104,40 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			},
 			errorMatcher: nil,
 		},
+		{
+			name:     fmt.Sprintf("case 5: set max replicas annotation when invalid"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMaxSize, "INVALID")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     int64(1),
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(1),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 5: set min replicas annotation when invalid"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, "INVALID")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     int64(1),
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(1),
+				},
+			},
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/machinepool/mutate_machinepool_update_test.go
+++ b/pkg/machinepool/mutate_machinepool_update_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/api/admission/v1beta1"
@@ -36,6 +37,69 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/spec/replicas",
 					Value:     int64(1),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 1: set min replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 2: set max replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 3: set min and max replicas annotation when replicas field is set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(7),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(7),
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:     fmt.Sprintf("case 4: set min and max replicas annotation when replicas field is not set"),
+			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     int64(1),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
+					Value:     int32(1),
+				},
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
+					Value:     int32(1),
 				},
 			},
 			errorMatcher: nil,

--- a/pkg/machinepool/mutate_machinepool_update_test.go
+++ b/pkg/machinepool/mutate_machinepool_update_test.go
@@ -48,7 +48,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -60,7 +60,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -72,12 +72,12 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(7),
+					Value:     "7",
 				},
 			},
 			errorMatcher: nil,
@@ -94,12 +94,12 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 				{
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 			},
 			errorMatcher: nil,
@@ -116,7 +116,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "replace",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 			},
 			errorMatcher: nil,
@@ -133,7 +133,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				{
 					Operation: "replace",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
-					Value:     int32(1),
+					Value:     "1",
 				},
 			},
 			errorMatcher: nil,


### PR DESCRIPTION
This is to fix the bug in 13.1.0 release that could end up having MachinePool CRs without the autoscaler annotations set.

Still to be tested on the field, but please have a look