### PR TITLE
Ensure azure-operator label when updating Cluster and AzureCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Ensure `azure-operator.giantswarm.io/version` label has the right value depending on the `release.giantswarm.io/version` label when updating `Cluster`.
+- Ensure `azure-operator.giantswarm.io/version` label has the right value depending on the `release.giantswarm.io/version`
+  label when updating `Cluster` and `AzureCluster`.
 
 ## [1.18.0] - 2021-01-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ensure `azure-operator.giantswarm.io/version` label has the right value depending on the `release.giantswarm.io/version` label when updating `Cluster`.
+
 ## [1.18.0] - 2021-01-15
 
 ### Added

--- a/integration/test/createnodepool/createnodepool_test.go
+++ b/integration/test/createnodepool/createnodepool_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
@@ -40,6 +41,7 @@ const (
 	infrastructureAPIGroup             = "infrastructure.cluster.x-k8s.io"
 	experimentalClusterAPIGroup        = "exp.cluster.x-k8s.io"
 	experimentalInfrastructureAPIGroup = "exp.infrastructure.cluster.x-k8s.io"
+	releaseAPIGroup                    = "release.giantswarm.io"
 	securityAPIGroup                   = "security.giantswarm.io"
 )
 
@@ -66,6 +68,7 @@ func TestCreateCluster(t *testing.T) {
 			securityv1alpha1.AddToScheme,
 			corev1.AddToScheme,
 			corev1alpha1.AddToScheme,
+			v1alpha1.AddToScheme,
 		}
 		err = appSchemeBuilder.AddToScheme(runtimeScheme)
 		if err != nil {
@@ -148,6 +151,7 @@ func getRequiredCRDs() []*apiextensionsv1.CustomResourceDefinition {
 		crd.LoadV1(clusterAPIGroup, "Cluster"),
 		crd.LoadV1(experimentalClusterAPIGroup, "MachinePool"),
 		crd.LoadV1(securityAPIGroup, "Organization"),
+		crd.LoadV1(releaseAPIGroup, "Release"),
 		crd.LoadV1(giantswarmCoreAPIGroup, "Spark"),
 	}
 }

--- a/integration/test/createnodepool/createnodepool_test.go
+++ b/integration/test/createnodepool/createnodepool_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/apiextensions/v3/pkg/crd"
 	"github.com/giantswarm/apptest"
@@ -68,7 +68,7 @@ func TestCreateCluster(t *testing.T) {
 			securityv1alpha1.AddToScheme,
 			corev1.AddToScheme,
 			corev1alpha1.AddToScheme,
-			v1alpha1.AddToScheme,
+			releasev1alpha1.AddToScheme,
 		}
 		err = appSchemeBuilder.AddToScheme(runtimeScheme)
 		if err != nil {

--- a/integration/test/createnodepool/testdata/1-release.yaml
+++ b/integration/test/createnodepool/testdata/1-release.yaml
@@ -1,10 +1,6 @@
 apiVersion: release.giantswarm.io/v1alpha1
 kind: Release
 metadata:
-  annotations:
-    release.giantswarm.io/ignore: "true"
-  finalizers:
-  - operatorkit.giantswarm.io/release-operator-release
   name: v13.0.1
 spec:
   apps:

--- a/integration/test/createnodepool/testdata/1-release.yaml
+++ b/integration/test/createnodepool/testdata/1-release.yaml
@@ -1,0 +1,74 @@
+apiVersion: release.giantswarm.io/v1alpha1
+kind: Release
+metadata:
+  annotations:
+    release.giantswarm.io/ignore: "true"
+  finalizers:
+  - operatorkit.giantswarm.io/release-operator-release
+  name: v13.0.1
+spec:
+  apps:
+  - catalog: default
+    name: cert-exporter
+    version: 1.3.0
+  - catalog: default
+    name: chart-operator
+    version: 2.5.1
+  - catalog: default
+    componentVersion: 1.6.5
+    name: coredns
+    version: 1.2.0
+  - catalog: default
+    componentVersion: 0.7.4
+    name: external-dns
+    version: 1.5.0
+  - catalog: default
+    componentVersion: 1.9.7
+    name: kube-state-metrics
+    version: 1.3.0
+  - catalog: default
+    componentVersion: 0.3.3
+    name: metrics-server
+    version: 1.1.0
+  - catalog: default
+    name: net-exporter
+    version: 1.9.2
+  - catalog: default
+    componentVersion: 1.0.1
+    name: node-exporter
+    version: 1.7.0
+  components:
+  - catalog: control-plane-catalog
+    name: app-operator
+    releaseOperatorDeploy: true
+    version: 2.7.0
+  - catalog: control-plane-catalog
+    name: azure-operator
+    releaseOperatorDeploy: true
+    version: 5.0.0
+  - catalog: control-plane-catalog
+    name: cert-operator
+    reference: 0.1.0-2
+    releaseOperatorDeploy: true
+    version: 0.1.0
+  - catalog: control-plane-catalog
+    name: cluster-operator
+    releaseOperatorDeploy: true
+    version: 0.23.19
+  - catalog: control-plane-catalog
+    name: kubernetes
+    version: 1.18.12
+  - catalog: control-plane-catalog
+    name: containerlinux
+    version: 2605.8.0
+  - catalog: control-plane-catalog
+    name: coredns
+    version: 1.6.5
+  - catalog: control-plane-catalog
+    name: calico
+    version: 3.15.3
+  - catalog: control-plane-catalog
+    name: etcd
+    version: 3.4.13
+  date: "2020-12-03T13:19:55Z"
+  state: deprecated

--- a/integration/test/createnodepool/testdata/2-azurecluster.yaml
+++ b/integration/test/createnodepool/testdata/2-azurecluster.yaml
@@ -6,7 +6,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: 2mw4b
     giantswarm.io/cluster: 2mw4b
     giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 13.0.0
+    release.giantswarm.io/version: 13.0.1
   name: 2mw4b
   namespace: org-giantswarm
 spec:

--- a/integration/test/createnodepool/testdata/3-cluster.yaml
+++ b/integration/test/createnodepool/testdata/3-cluster.yaml
@@ -9,7 +9,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: 2mw4b
     giantswarm.io/cluster: 2mw4b
     giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 13.0.0
+    release.giantswarm.io/version: 13.0.1
   name: 2mw4b
   namespace: org-giantswarm
 spec:

--- a/integration/test/createnodepool/testdata/4-spark.yaml
+++ b/integration/test/createnodepool/testdata/4-spark.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: 2mw4b
     giantswarm.io/cluster: 2mw4b
-    release.giantswarm.io/version: 13.0.0
+    release.giantswarm.io/version: 13.0.1
   name: 8c7mn
   namespace: org-giantswarm
 spec: {}

--- a/integration/test/createnodepool/testdata/5-azuremachinepool.yaml
+++ b/integration/test/createnodepool/testdata/5-azuremachinepool.yaml
@@ -7,7 +7,7 @@ metadata:
     giantswarm.io/cluster: 2mw4b
     giantswarm.io/machine-pool: 8c7mn
     giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 13.0.0
+    release.giantswarm.io/version: 13.0.1
   name: 8c7mn
   namespace: org-giantswarm
 spec:

--- a/integration/test/createnodepool/testdata/6-machinepool.yaml
+++ b/integration/test/createnodepool/testdata/6-machinepool.yaml
@@ -10,7 +10,7 @@ metadata:
     giantswarm.io/cluster: 2mw4b
     giantswarm.io/machine-pool: 8c7mn
     giantswarm.io/organization: giantswarm
-    release.giantswarm.io/version: 13.0.0
+    release.giantswarm.io/version: 13.0.1
   name: 8c7mn
   namespace: org-giantswarm
 spec:

--- a/integration/util/yaml.go
+++ b/integration/util/yaml.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -106,6 +107,8 @@ func unmarshal(bs []byte) (runtime.Object, error) {
 		obj = new(capzv1alpha3.AzureMachine)
 	case "AzureMachinePool":
 		obj = new(expcapzv1alpha3.AzureMachinePool)
+	case "Release":
+		obj = new(releasev1alpha1.Release)
 	case "Spark":
 		obj = new(corev1alpha1.Spark)
 	default:

--- a/integration/util/yaml.go
+++ b/integration/util/yaml.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	releasev1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/test/cluster/builder.go
+++ b/internal/test/cluster/builder.go
@@ -1,0 +1,78 @@
+package cluster
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/test"
+)
+
+type BuilderOption func(cluster *capiv1alpha3.Cluster) *capiv1alpha3.Cluster
+
+func Name(name string) BuilderOption {
+	return func(cluster *capiv1alpha3.Cluster) *capiv1alpha3.Cluster {
+		cluster.ObjectMeta.Name = name
+		cluster.Labels[capiv1alpha3.ClusterLabelName] = name
+		cluster.Labels[label.Cluster] = name
+		return cluster
+	}
+}
+
+func Labels(labels map[string]string) BuilderOption {
+	return func(cluster *capiv1alpha3.Cluster) *capiv1alpha3.Cluster {
+		for k, v := range labels {
+			cluster.Labels[k] = v
+		}
+		return cluster
+	}
+}
+
+func BuildCluster(opts ...BuilderOption) *capiv1alpha3.Cluster {
+	clusterName := test.GenerateName()
+	cluster := &capiv1alpha3.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: capiv1alpha3.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: "org-giantswarm",
+			Labels: map[string]string{
+				label.AzureOperatorVersion:    "5.0.0",
+				capiv1alpha3.ClusterLabelName: clusterName,
+				label.Cluster:                 clusterName,
+				label.Organization:            "giantswarm",
+				label.ReleaseVersion:          "13.0.0-alpha4",
+			},
+		},
+		Spec: capiv1alpha3.ClusterSpec{
+			ClusterNetwork: &capiv1alpha3.ClusterNetwork{
+				APIServerPort: to.Int32Ptr(443),
+				ServiceDomain: "cluster.local",
+				Services: &capiv1alpha3.NetworkRanges{
+					CIDRBlocks: []string{
+						"172.31.0.0/16",
+					},
+				},
+			},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(cluster)
+	}
+
+	return cluster
+}
+
+func BuildClusterAsJson(opts ...BuilderOption) []byte {
+	cluster := BuildCluster(opts...)
+
+	byt, _ := json.Marshal(cluster)
+
+	return byt
+}

--- a/main.go
+++ b/main.go
@@ -143,6 +143,18 @@ func mainError() error {
 		}
 	}
 
+	var azureClusterUpdateMutator *azurecluster.UpdateMutator
+	{
+		conf := azurecluster.UpdateMutatorConfig{
+			CtrlClient: ctrlClient,
+			Logger:     newLogger,
+		}
+		azureClusterUpdateMutator, err = azurecluster.NewUpdateMutator(conf)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var azureClusterConfigValidator *azureupdate.AzureClusterConfigValidator
 	{
 		azureClusterConfigValidatorConfig := azureupdate.AzureClusterConfigValidatorConfig{
@@ -375,6 +387,7 @@ func mainError() error {
 	handler.Handle("/mutate/azuremachine/create", mutator.Handler(azureMachineCreateMutator))
 	handler.Handle("/mutate/azuremachinepool/create", mutator.Handler(azureMachinePoolCreateMutator))
 	handler.Handle("/mutate/azurecluster/create", mutator.Handler(azureClusterCreateMutator))
+	handler.Handle("/mutate/azurecluster/update", mutator.Handler(azureClusterUpdateMutator))
 	handler.Handle("/mutate/cluster/create", mutator.Handler(clusterCreateMutator))
 	handler.Handle("/mutate/cluster/update", mutator.Handler(clusterUpdateMutator))
 	handler.Handle("/mutate/machinepool/create", mutator.Handler(machinePoolCreateMutator))

--- a/main.go
+++ b/main.go
@@ -273,6 +273,18 @@ func mainError() error {
 		}
 	}
 
+	var clusterUpdateMutator *cluster.UpdateMutator
+	{
+		conf := cluster.UpdateMutatorConfig{
+			CtrlClient: ctrlClient,
+			Logger:     newLogger,
+		}
+		clusterUpdateMutator, err = cluster.NewUpdateMutator(conf)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var clusterCreateValidator *cluster.CreateValidator
 	{
 		c := cluster.CreateValidatorConfig{
@@ -364,6 +376,7 @@ func mainError() error {
 	handler.Handle("/mutate/azuremachinepool/create", mutator.Handler(azureMachinePoolCreateMutator))
 	handler.Handle("/mutate/azurecluster/create", mutator.Handler(azureClusterCreateMutator))
 	handler.Handle("/mutate/cluster/create", mutator.Handler(clusterCreateMutator))
+	handler.Handle("/mutate/cluster/update", mutator.Handler(clusterUpdateMutator))
 	handler.Handle("/mutate/machinepool/create", mutator.Handler(machinePoolCreateMutator))
 	handler.Handle("/mutate/machinepool/update", mutator.Handler(machinePoolUpdateMutator))
 	handler.Handle("/mutate/spark/create", mutator.Handler(sparkCreateMutator))

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -1,0 +1,73 @@
+package azurecluster
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+)
+
+type UpdateMutator struct {
+	ctrlClient ctrl.Client
+	logger     micrologger.Logger
+}
+
+type UpdateMutatorConfig struct {
+	CtrlClient ctrl.Client
+	Logger     micrologger.Logger
+}
+
+func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	m := &UpdateMutator{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return m, nil
+}
+
+func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+
+	if request.DryRun != nil && *request.DryRun {
+		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
+		return result, nil
+	}
+
+	azureClusterCR := &capz.AzureCluster{}
+	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureClusterCR); err != nil {
+		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse AzureCluster CR: %v", err)
+	}
+
+	patch, err := generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if patch != nil {
+		result = append(result, *patch)
+	}
+
+	return result, nil
+}
+
+func (m *UpdateMutator) Log(keyVals ...interface{}) {
+	m.logger.Log(keyVals...)
+}
+
+func (m *UpdateMutator) Resource() string {
+	return "azurecluster"
+}

--- a/pkg/azurecluster/mutate_update_test.go
+++ b/pkg/azurecluster/mutate_update_test.go
@@ -1,0 +1,127 @@
+package azurecluster
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/azurecluster"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
+)
+
+func TestAzureClusterUpdateMutate(t *testing.T) {
+	type testCase struct {
+		name         string
+		cluster      []byte
+		patches      []mutator.PatchOperation
+		errorMatcher func(err error) bool
+	}
+
+	testCases := []testCase{
+		{
+			name:    fmt.Sprintf("case 0: Wrong azure-operator component label"),
+			cluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0"})),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/azure-operator.giantswarm.io~1version",
+					Value:     "5.1.0",
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+
+			ctx := context.Background()
+			fakeK8sClient := unittest.FakeK8sClient()
+			ctrlClient := fakeK8sClient.CtrlClient()
+
+			release131 := &v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "v13.1.0",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ReleaseSpec{
+					Components: []v1alpha1.ReleaseSpecComponent{
+						{
+							Name:    "azure-operator",
+							Version: "5.1.0",
+						},
+					},
+				},
+			}
+			err = ctrlClient.Create(ctx, release131)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			admit, err := NewUpdateMutator(UpdateMutatorConfig{
+				CtrlClient: ctrlClient,
+				Logger:     newLogger,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Run admission request to validate AzureConfig updates.
+			patches, err := admit.Mutate(context.Background(), getUpdateMutateAdmissionRequest(tc.cluster))
+
+			// Check if the error is the expected one.
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// fall through
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("expected %#v got %#v", nil, err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("expected %#v got %#v", "error", nil)
+			case !tc.errorMatcher(err):
+				t.Fatalf("unexpected error: %#v", err)
+			}
+
+			// Check if the validation result is the expected one.
+			if len(tc.patches) != 0 || len(patches) != 0 {
+				if !reflect.DeepEqual(tc.patches, patches) {
+					t.Fatalf("Patches mismatch: expected %v, got %v", tc.patches, patches)
+				}
+			}
+		})
+	}
+}
+
+func getUpdateMutateAdmissionRequest(newAzureCluster []byte) *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Resource: metav1.GroupVersionResource{
+			Version:  "infrastructure.cluster.x-k8s.io/v1alpha3",
+			Resource: "azurecluster",
+		},
+		Operation: v1beta1.Update,
+		Object: runtime.RawExtension{
+			Raw:    newAzureCluster,
+			Object: nil,
+		},
+	}
+
+	return req
+}

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -1,0 +1,73 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+)
+
+type UpdateMutator struct {
+	ctrlClient ctrl.Client
+	logger     micrologger.Logger
+}
+
+type UpdateMutatorConfig struct {
+	CtrlClient ctrl.Client
+	Logger     micrologger.Logger
+}
+
+func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	m := &UpdateMutator{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return m, nil
+}
+
+func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var result []mutator.PatchOperation
+
+	if request.DryRun != nil && *request.DryRun {
+		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
+		return result, nil
+	}
+
+	clusterCR := &capi.Cluster{}
+	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, clusterCR); err != nil {
+		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse Cluster CR: %v", err)
+	}
+
+	patch, err := generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if patch != nil {
+		result = append(result, *patch)
+	}
+
+	return result, nil
+}
+
+func (m *UpdateMutator) Log(keyVals ...interface{}) {
+	m.logger.Log(keyVals...)
+}
+
+func (m *UpdateMutator) Resource() string {
+	return "cluster"
+}

--- a/pkg/cluster/mutate_update_test.go
+++ b/pkg/cluster/mutate_update_test.go
@@ -1,0 +1,127 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/cluster"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
+)
+
+func TestClusterUpdateMutate(t *testing.T) {
+	type testCase struct {
+		name         string
+		cluster      []byte
+		patches      []mutator.PatchOperation
+		errorMatcher func(err error) bool
+	}
+
+	testCases := []testCase{
+		{
+			name:    fmt.Sprintf("case 0: Wrong azure-operator component label"),
+			cluster: builder.BuildClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0"})),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/azure-operator.giantswarm.io~1version",
+					Value:     "5.1.0",
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			// Create a new logger that is used by all admitters.
+			var newLogger micrologger.Logger
+			{
+				newLogger, err = micrologger.New(micrologger.Config{})
+				if err != nil {
+					panic(microerror.JSON(err))
+				}
+			}
+
+			ctx := context.Background()
+			fakeK8sClient := unittest.FakeK8sClient()
+			ctrlClient := fakeK8sClient.CtrlClient()
+
+			release131 := &v1alpha1.Release{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "v13.1.0",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ReleaseSpec{
+					Components: []v1alpha1.ReleaseSpecComponent{
+						{
+							Name:    "azure-operator",
+							Version: "5.1.0",
+						},
+					},
+				},
+			}
+			err = ctrlClient.Create(ctx, release131)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			admit, err := NewUpdateMutator(UpdateMutatorConfig{
+				CtrlClient: ctrlClient,
+				Logger:     newLogger,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Run admission request to validate AzureConfig updates.
+			patches, err := admit.Mutate(context.Background(), getUpdateMutateAdmissionRequest(tc.cluster))
+
+			// Check if the error is the expected one.
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// fall through
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("expected %#v got %#v", nil, err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("expected %#v got %#v", "error", nil)
+			case !tc.errorMatcher(err):
+				t.Fatalf("unexpected error: %#v", err)
+			}
+
+			// Check if the validation result is the expected one.
+			if len(tc.patches) != 0 || len(patches) != 0 {
+				if !reflect.DeepEqual(tc.patches, patches) {
+					t.Fatalf("Patches mismatch: expected %v, got %v", tc.patches, patches)
+				}
+			}
+		})
+	}
+}
+
+func getUpdateMutateAdmissionRequest(newCluster []byte) *v1beta1.AdmissionRequest {
+	req := &v1beta1.AdmissionRequest{
+		Resource: metav1.GroupVersionResource{
+			Version:  "cluster.x-k8s.io/v1alpha3",
+			Resource: "cluster",
+		},
+		Operation: v1beta1.Update,
+		Object: runtime.RawExtension{
+			Raw:    newCluster,
+			Object: nil,
+		},
+	}
+
+	return req
+}


### PR DESCRIPTION
With these changes the admission controller would automatically set the right azure-operator component label to `Cluster` and `AzureCluster`. The right value for the label is taken from the `Release` used.