### PR TITLE
Add cluster mutate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add cluster mutate webhook definition in the Helm chart.
+
 ## [2.1.0] - 2021-02-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add cluster mutate webhook definition in the Helm chart.
-
+- Add `Cluster` and `AzureCluster` mutate webhook definition in the Helm chart.
+- Ensure `cluster-operator.giantswarm.io/version` label has the right value depending on the `release.giantswarm.io/version`
+  label when updating `Cluster` and `AzureCluster`.
+  
 ## [2.1.0] - 2021-02-03
 
 ### Added

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -81,6 +81,24 @@ webhooks:
         - CREATE
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
+- name: mutate.clusters.update.{{ include "resource.default.name" . }}.giantswarm.io
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "resource.default.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /mutate/cluster/update
+    caBundle: Cg==
+  rules:
+    - apiGroups: ["cluster.x-k8s.io"]
+      resources:
+        - "clusters"
+      apiVersions:
+        - "v1alpha3"
+      operations:
+        - UPDATE
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
 - name: mutate.machinepools.create.{{ include "resource.default.name" . }}.giantswarm.io
   failurePolicy: Fail
   clientConfig:

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -27,6 +27,24 @@ webhooks:
         - CREATE
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
+- name: mutate.azureclusters.update.{{ include "resource.default.name" . }}.giantswarm.io
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "resource.default.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /mutate/azurecluster/update
+    caBundle: Cg==
+  rules:
+    - apiGroups: ["infrastructure.cluster.x-k8s.io"]
+      resources:
+        - "azureclusters"
+      apiVersions:
+        - "v1alpha3"
+      operations:
+        - UPDATE
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
 - name: mutate.azuremachines.create.{{ include "resource.default.name" . }}.giantswarm.io
   failurePolicy: Fail
   clientConfig:

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -61,6 +61,14 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
+	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if patch != nil {
+		result = append(result, *patch)
+	}
+
 	return result, nil
 }
 

--- a/pkg/azurecluster/mutate_update_test.go
+++ b/pkg/azurecluster/mutate_update_test.go
@@ -29,12 +29,24 @@ func TestAzureClusterUpdateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    fmt.Sprintf("case 0: Wrong azure-operator component label"),
-			cluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0"})),
+			cluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0", "cluster-operator.giantswarm.io/version": "0.23.11"})),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
 					Path:      "/metadata/labels/azure-operator.giantswarm.io~1version",
 					Value:     "5.1.0",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:    fmt.Sprintf("case 1: Wrong cluster-operator component label"),
+			cluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "5.1.0", "cluster-operator.giantswarm.io/version": "0.23.10"})),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/cluster-operator.giantswarm.io~1version",
+					Value:     "0.23.11",
 				},
 			},
 			errorMatcher: nil,
@@ -68,6 +80,10 @@ func TestAzureClusterUpdateMutate(t *testing.T) {
 						{
 							Name:    "azure-operator",
 							Version: "5.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.23.11",
 						},
 					},
 				},

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -61,6 +61,14 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
+	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if patch != nil {
+		result = append(result, *patch)
+	}
+
 	return result, nil
 }
 

--- a/pkg/cluster/mutate_update_test.go
+++ b/pkg/cluster/mutate_update_test.go
@@ -29,12 +29,24 @@ func TestClusterUpdateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    fmt.Sprintf("case 0: Wrong azure-operator component label"),
-			cluster: builder.BuildClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0"})),
+			cluster: builder.BuildClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "4.2.0", "cluster-operator.giantswarm.io/version": "0.23.11"})),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
 					Path:      "/metadata/labels/azure-operator.giantswarm.io~1version",
 					Value:     "5.1.0",
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name:    fmt.Sprintf("case 0: Wrong azure-operator component label"),
+			cluster: builder.BuildClusterAsJson(builder.Name("ab123"), builder.Labels(map[string]string{"release.giantswarm.io/version": "v13.1.0", "azure-operator.giantswarm.io/version": "5.1.0", "cluster-operator.giantswarm.io/version": "0.23.10"})),
+			patches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/labels/cluster-operator.giantswarm.io~1version",
+					Value:     "0.23.11",
 				},
 			},
 			errorMatcher: nil,
@@ -68,6 +80,10 @@ func TestClusterUpdateMutate(t *testing.T) {
 						{
 							Name:    "azure-operator",
 							Version: "5.1.0",
+						},
+						{
+							Name:    "cluster-operator",
+							Version: "0.23.11",
 						},
 					},
 				},


### PR DESCRIPTION
Added missing mutating webhook declaration in the helm chart.
Added automatic adjusting of the cluster-operator label according to the release version for `Cluster` and `AzureCluster`.