### PR TITLE
Use CAPI/CAPZ defaulting for all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Execute CAPZ validation for all resources.
+- Execute CAPI/CAPZ validation for all resources.
+- Execute CAPI/CAPZ defaulting on all resources.
 
 ## [2.2.0] - 2021-02-05
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/giantswarm/micrologger v0.5.0
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
+	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	k8s.io/api v0.18.9
 	k8s.io/apiextensions-apiserver v0.18.9

--- a/helm/azure-admission-controller/templates/webhook.yaml
+++ b/helm/azure-admission-controller/templates/webhook.yaml
@@ -99,6 +99,24 @@ webhooks:
         - CREATE
   sideEffects: None
   admissionReviewVersions: ["v1", "v1beta1"]
+- name: mutate.azuremachinepools.update.{{ include "resource.default.name" . }}.giantswarm.io
+  failurePolicy: Fail
+  clientConfig:
+    service:
+      name: {{ include "resource.default.name" . }}
+      namespace: {{ include "resource.default.namespace" . }}
+      path: /mutate/azuremachinepool/update
+    caBundle: Cg==
+  rules:
+    - apiGroups: ["exp.infrastructure.cluster.x-k8s.io"]
+      resources:
+        - "azuremachinepools"
+      apiVersions:
+        - "v1alpha3"
+      operations:
+        - UPDATE
+  sideEffects: None
+  admissionReviewVersions: ["v1", "v1beta1"]
 - name: mutate.clusters.create.{{ include "resource.default.name" . }}.giantswarm.io
   failurePolicy: Fail
   clientConfig:

--- a/internal/patches/patches.go
+++ b/internal/patches/patches.go
@@ -1,0 +1,47 @@
+package patches
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+	"github.com/giantswarm/microerror"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func GeneratePatchesFrom(originalJSON []byte, current runtime.Object) ([]mutator.PatchOperation, error) {
+	currentJSON, err := json.Marshal(current)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var patches []mutator.PatchOperation
+	{
+		var jsonPatches []jsonpatch.JsonPatchOperation
+		jsonPatches, err = jsonpatch.CreatePatch(originalJSON, currentJSON)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		patches = make([]mutator.PatchOperation, 0, len(jsonPatches))
+		for _, patch := range jsonPatches {
+			patches = append(patches, mutator.PatchOperation(patch))
+		}
+	}
+
+	return patches, nil
+}
+
+func SkipPatchesForPath(path string, patches []mutator.PatchOperation) []mutator.PatchOperation {
+	var modifiedPatches []mutator.PatchOperation
+	{
+		for _, patch := range patches {
+			if !strings.HasPrefix(patch.Path, path) {
+				modifiedPatches = append(modifiedPatches, patch)
+			}
+		}
+	}
+
+	return modifiedPatches
+}

--- a/internal/patches/patches.go
+++ b/internal/patches/patches.go
@@ -5,10 +5,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/microerror"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
 func GeneratePatchesFrom(originalJSON []byte, current runtime.Object) ([]mutator.PatchOperation, error) {

--- a/internal/patches/patches.go
+++ b/internal/patches/patches.go
@@ -2,6 +2,7 @@ package patches
 
 import (
 	"encoding/json"
+	"sort"
 	"strings"
 
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -28,6 +29,10 @@ func GeneratePatchesFrom(originalJSON []byte, current runtime.Object) ([]mutator
 		for _, patch := range jsonPatches {
 			patches = append(patches, mutator.PatchOperation(patch))
 		}
+
+		sort.SliceStable(patches, func(i, j int) bool {
+			return patches[i].Path < patches[j].Path
+		})
 	}
 
 	return patches, nil

--- a/internal/patches/patches.go
+++ b/internal/patches/patches.go
@@ -12,7 +12,7 @@ import (
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-func GeneratePatchesFrom(originalJSON []byte, current runtime.Object) ([]mutator.PatchOperation, error) {
+func GenerateFrom(originalJSON []byte, current runtime.Object) ([]mutator.PatchOperation, error) {
 	currentJSON, err := json.Marshal(current)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -39,7 +39,7 @@ func GeneratePatchesFrom(originalJSON []byte, current runtime.Object) ([]mutator
 	return patches, nil
 }
 
-func SkipPatchesForPath(path string, patches []mutator.PatchOperation) []mutator.PatchOperation {
+func SkipForPath(path string, patches []mutator.PatchOperation) []mutator.PatchOperation {
 	var modifiedPatches []mutator.PatchOperation
 	{
 		for _, patch := range patches {

--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -12,7 +12,7 @@ import (
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
-func TestGeneratePatchesFrom(t *testing.T) {
+func TestGenerateFrom(t *testing.T) {
 	testCases := []struct {
 		name            string
 		originalObject  runtime.Object
@@ -54,7 +54,7 @@ func TestGeneratePatchesFrom(t *testing.T) {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
 
-			patches, err := GeneratePatchesFrom(originalObjectJSON, tc.currentObject)
+			patches, err := GenerateFrom(originalObjectJSON, tc.currentObject)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err.Error())
 			}
@@ -70,7 +70,7 @@ func TestGeneratePatchesFrom(t *testing.T) {
 	}
 }
 
-func TestSkipPatchesForPath(t *testing.T) {
+func TestSkipForPath(t *testing.T) {
 	patches := []mutator.PatchOperation{
 		{
 			Operation: "add",
@@ -104,7 +104,7 @@ func TestSkipPatchesForPath(t *testing.T) {
 		},
 	}
 
-	filteredPatches := SkipPatchesForPath("/spec/test", patches)
+	filteredPatches := SkipForPath("/spec/test", patches)
 
 	if !reflect.DeepEqual(expectedPatches, filteredPatches) {
 		t.Fatalf("patches mismatch: expected %v, got %v", expectedPatches, filteredPatches)

--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -5,8 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )

--- a/internal/patches/patches_test.go
+++ b/internal/patches/patches_test.go
@@ -1,0 +1,111 @@
+package patches
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+)
+
+func TestGeneratePatchesFrom(t *testing.T) {
+	testCases := []struct {
+		name            string
+		originalObject  runtime.Object
+		currentObject   runtime.Object
+		expectedPatches []mutator.PatchOperation
+	}{
+		{
+			name:            "case 0 finds no difference between identical objects",
+			originalObject:  &capiv1alpha3.Cluster{},
+			currentObject:   &capiv1alpha3.Cluster{},
+			expectedPatches: []mutator.PatchOperation{},
+		},
+		{
+			name:           "case 1 finds the differences between two compatible objects",
+			originalObject: &capiv1alpha3.Cluster{},
+			currentObject: &capiv1alpha3.Cluster{
+				Spec: capiv1alpha3.ClusterSpec{ClusterNetwork: &capiv1alpha3.ClusterNetwork{Services: &capiv1alpha3.NetworkRanges{CIDRBlocks: []string{"1", "2", "3"}}}},
+			},
+			expectedPatches: []mutator.PatchOperation{
+				{
+					Operation: "add",
+					Path:      "/spec/clusterNetwork",
+					Value: map[string]interface{}{
+						"services": map[string]interface{}{
+							"cidrBlocks": []interface{}{
+								"1", "2", "3",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalObjectJSON, err := json.Marshal(tc.originalObject)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			patches, err := GeneratePatchesFrom(originalObjectJSON, tc.currentObject)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err.Error())
+			}
+
+			if len(tc.expectedPatches) == 0 && len(patches) == 0 {
+				return
+			}
+
+			if !reflect.DeepEqual(tc.expectedPatches, patches) {
+				t.Fatalf("patches mismatch: expected %v, got %v", tc.expectedPatches, patches)
+			}
+		})
+	}
+}
+
+func TestSkipPatchesForPath(t *testing.T) {
+	patches := []mutator.PatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/test",
+		},
+		{
+			Operation: "remove",
+			Path:      "/spec/test/someother/other",
+		},
+		{
+			Operation: "add",
+			Path:      "/justapath/test",
+		},
+		{
+			Operation: "add",
+			Path:      "/testPath",
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/test/someother",
+		},
+	}
+	expectedPatches := []mutator.PatchOperation{
+		{
+			Operation: "add",
+			Path:      "/justapath/test",
+		},
+		{
+			Operation: "add",
+			Path:      "/testPath",
+		},
+	}
+
+	filteredPatches := SkipPatchesForPath("/spec/test", patches)
+
+	if !reflect.DeepEqual(expectedPatches, filteredPatches) {
+		t.Fatalf("patches mismatch: expected %v, got %v", expectedPatches, filteredPatches)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -206,6 +206,18 @@ func mainError() error {
 		}
 	}
 
+	var azureMachinePoolUpdateMutator *azuremachinepool.UpdateMutator
+	{
+		updateMutatorConfig := azuremachinepool.UpdateMutatorConfig{
+			CtrlClient: ctrlClient,
+			Logger:     newLogger,
+		}
+		azureMachinePoolUpdateMutator, err = azuremachinepool.NewUpdateMutator(updateMutatorConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var azureMachinePoolCreateValidator *azuremachinepool.CreateValidator
 	{
 		createValidatorConfig := azuremachinepool.CreateValidatorConfig{
@@ -399,6 +411,7 @@ func mainError() error {
 	handler.Handle("/mutate/azuremachine/create", mutator.Handler(azureMachineCreateMutator))
 	handler.Handle("/mutate/azuremachine/update", mutator.Handler(azureMachineUpdateMutator))
 	handler.Handle("/mutate/azuremachinepool/create", mutator.Handler(azureMachinePoolCreateMutator))
+	handler.Handle("/mutate/azuremachinepool/update", mutator.Handler(azureMachinePoolUpdateMutator))
 	handler.Handle("/mutate/azurecluster/create", mutator.Handler(azureClusterCreateMutator))
 	handler.Handle("/mutate/azurecluster/update", mutator.Handler(azureClusterUpdateMutator))
 	handler.Handle("/mutate/cluster/create", mutator.Handler(clusterCreateMutator))

--- a/pkg/azurecluster/mutate_create.go
+++ b/pkg/azurecluster/mutate_create.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -137,6 +138,20 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	azureClusterCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureClusterCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/vnet", capiPatches)
+		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/subnets", capiPatches)
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/azurecluster/mutate_create.go
+++ b/pkg/azurecluster/mutate_create.go
@@ -143,13 +143,13 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureClusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureClusterCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureClusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/vnet", capiPatches)
-		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/subnets", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/networkSpec/vnet", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/networkSpec/subnets", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -11,6 +11,7 @@ import (
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -109,6 +110,20 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	azureClusterCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureClusterCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/vnet", capiPatches)
+		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/subnets", capiPatches)
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -115,13 +115,13 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureClusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureClusterCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureClusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/vnet", capiPatches)
-		capiPatches = patches.SkipPatchesForPath("/spec/networkSpec/subnets", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/networkSpec/vnet", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/networkSpec/subnets", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/azuremachine/mutate_create.go
+++ b/pkg/azuremachine/mutate_create.go
@@ -87,12 +87,12 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMachineCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMachineCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMachineCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/sshPublicKey", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/sshPublicKey", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/azuremachine/mutate_create.go
+++ b/pkg/azuremachine/mutate_create.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -81,6 +82,19 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	azureMachineCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMachineCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		capiPatches = patches.SkipPatchesForPath("/spec/sshPublicKey", capiPatches)
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/azuremachine/mutate_update.go
+++ b/pkg/azuremachine/mutate_update.go
@@ -64,12 +64,12 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMachineCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMachineCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMachineCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/sshPublicKey", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/sshPublicKey", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/azuremachinepool/mutate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/mutate_azuremachinepool_create.go
@@ -10,6 +10,7 @@ import (
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -104,6 +105,19 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	azureMPCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMPCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		capiPatches = patches.SkipPatchesForPath("/spec/template/sshPublicKey", capiPatches)
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/azuremachinepool/mutate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/mutate_azuremachinepool_create.go
@@ -110,12 +110,12 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMPCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMPCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMPCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/template/sshPublicKey", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/template/sshPublicKey", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/azuremachinepool/mutate_update.go
+++ b/pkg/azuremachinepool/mutate_update.go
@@ -1,0 +1,78 @@
+package azuremachinepool
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/admission/v1beta1"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+)
+
+type UpdateMutator struct {
+	ctrlClient ctrl.Client
+	logger     micrologger.Logger
+}
+
+type UpdateMutatorConfig struct {
+	CtrlClient ctrl.Client
+	Logger     micrologger.Logger
+}
+
+func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	m := &UpdateMutator{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return m, nil
+}
+
+func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var err error
+	var result []mutator.PatchOperation
+
+	if request.DryRun != nil && *request.DryRun {
+		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
+		return result, nil
+	}
+
+	azureMPCR := &expcapzv1alpha3.AzureMachinePool{}
+	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureMPCR); err != nil {
+		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
+	}
+
+	azureMPCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMPCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		capiPatches = patches.SkipPatchesForPath("/spec/template/sshPublicKey", capiPatches)
+
+		result = append(result, capiPatches...)
+	}
+
+	return result, nil
+}
+
+func (m *UpdateMutator) Log(keyVals ...interface{}) {
+	m.logger.Log(keyVals...)
+}
+
+func (m *UpdateMutator) Resource() string {
+	return "azurecluster"
+}

--- a/pkg/azuremachinepool/mutate_update.go
+++ b/pkg/azuremachinepool/mutate_update.go
@@ -56,12 +56,12 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMPCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, azureMPCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMPCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
 
-		capiPatches = patches.SkipPatchesForPath("/spec/template/sshPublicKey", capiPatches)
+		capiPatches = patches.SkipForPath("/spec/template/sshPublicKey", capiPatches)
 
 		result = append(result, capiPatches...)
 	}

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -97,7 +97,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	clusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, clusterCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, clusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -91,6 +92,17 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	clusterCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, clusterCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -73,7 +73,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	clusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, clusterCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, clusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -10,6 +10,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
@@ -67,6 +68,17 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 	if patch != nil {
 		result = append(result, *patch)
+	}
+
+	clusterCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, clusterCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -1,8 +1,6 @@
 package machinepool
 
 import (
-	"fmt"
-
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
@@ -15,21 +13,5 @@ const defaultReplicas int64 = 1
 func setDefaultSpecValues(m mutator.Mutator, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
 	var patches []mutator.PatchOperation
 
-	defaultSpecReplicas := setDefaultReplicaValue(m, machinePool)
-	if defaultSpecReplicas != nil {
-		patches = append(patches, *defaultSpecReplicas)
-	}
-
 	return patches
-}
-
-// setDefaultReplicaValue checks if Spec.Replicas has been set, and if it is
-// not, it sets its value to 1.
-func setDefaultReplicaValue(m mutator.Mutator, machinePool *capiexp.MachinePool) *mutator.PatchOperation {
-	if machinePool.Spec.Replicas == nil {
-		m.Log("level", "debug", "message", fmt.Sprintf("setting default MachinePool.Spec.Replicas to %d", defaultReplicas))
-		return mutator.PatchAdd("/spec/replicas", defaultReplicas)
-	}
-
-	return nil
 }

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -9,6 +9,7 @@ import (
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
@@ -73,9 +74,20 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patches := ensureAutoscalingAnnotations(m, machinePoolCR)
-	if patches != nil {
-		result = append(result, patches...)
+	autoscalingPatches := ensureAutoscalingAnnotations(m, machinePoolCR)
+	if autoscalingPatches != nil {
+		result = append(result, autoscalingPatches...)
+	}
+
+	machinePoolCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, machinePoolCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -82,7 +82,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	machinePoolCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, machinePoolCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, machinePoolCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}

--- a/pkg/machinepool/mutate_machinepool_create_test.go
+++ b/pkg/machinepool/mutate_machinepool_create_test.go
@@ -34,9 +34,19 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 			nodePool: builder.BuildMachinePoolAsJson(),
 			patches: []mutator.PatchOperation{
 				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
 					Operation: "add",
 					Path:      "/spec/replicas",
-					Value:     int64(1),
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,
@@ -50,6 +60,16 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
 					Value:     "7",
 				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
 			},
 			errorMatcher: nil,
 		},
@@ -61,6 +81,16 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "7",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
 				},
 			},
 			errorMatcher: nil,
@@ -79,6 +109,16 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "7",
 				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
 			},
 			errorMatcher: nil,
 		},
@@ -88,11 +128,6 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
-					Path:      "/spec/replicas",
-					Value:     int64(1),
-				},
-				{
-					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
 					Value:     "1",
 				},
@@ -100,6 +135,21 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "1",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,

--- a/pkg/machinepool/mutate_machinepool_update.go
+++ b/pkg/machinepool/mutate_machinepool_update.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/api/admission/v1beta1"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
+	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
@@ -32,6 +33,7 @@ func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
 }
 
 func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+	var err error
 	var result []mutator.PatchOperation
 
 	if request.DryRun != nil && *request.DryRun {
@@ -55,6 +57,17 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	patch := ensureAutoscalingAnnotations(m, machinePoolCR)
 	if patch != nil {
 		result = append(result, patch...)
+	}
+
+	machinePoolCR.Default()
+	{
+		var capiPatches []mutator.PatchOperation
+		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, machinePoolCR)
+		if err != nil {
+			return []mutator.PatchOperation{}, microerror.Mask(err)
+		}
+
+		result = append(result, capiPatches...)
 	}
 
 	return result, nil

--- a/pkg/machinepool/mutate_machinepool_update.go
+++ b/pkg/machinepool/mutate_machinepool_update.go
@@ -62,7 +62,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	machinePoolCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GeneratePatchesFrom(request.Object.Raw, machinePoolCR)
+		capiPatches, err = patches.GenerateFrom(request.Object.Raw, machinePoolCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}

--- a/pkg/machinepool/mutate_machinepool_update_test.go
+++ b/pkg/machinepool/mutate_machinepool_update_test.go
@@ -34,9 +34,19 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			nodePool: builder.BuildMachinePoolAsJson(),
 			patches: []mutator.PatchOperation{
 				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
 					Operation: "add",
 					Path:      "/spec/replicas",
-					Value:     int64(1),
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,
@@ -50,6 +60,16 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
 					Value:     "7",
 				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
 			},
 			errorMatcher: nil,
 		},
@@ -61,6 +81,16 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "7",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
 				},
 			},
 			errorMatcher: nil,
@@ -79,6 +109,16 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "7",
 				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
 			},
 			errorMatcher: nil,
 		},
@@ -88,11 +128,6 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
-					Path:      "/spec/replicas",
-					Value:     int64(1),
-				},
-				{
-					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
 					Value:     "1",
 				},
@@ -100,6 +135,21 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 					Operation: "add",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "1",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,
@@ -109,31 +159,51 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMaxSize, "INVALID")),
 			patches: []mutator.PatchOperation{
 				{
-					Operation: "add",
-					Path:      "/spec/replicas",
-					Value:     int64(1),
-				},
-				{
 					Operation: "replace",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-max-size",
 					Value:     "1",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,
 		},
 		{
-			name:     fmt.Sprintf("case 5: set min replicas annotation when invalid"),
+			name:     fmt.Sprintf("case 6: set min replicas annotation when invalid"),
 			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, "INVALID")),
 			patches: []mutator.PatchOperation{
-				{
-					Operation: "add",
-					Path:      "/spec/replicas",
-					Value:     int64(1),
-				},
 				{
 					Operation: "replace",
 					Path:      "/metadata/annotations/cluster.k8s.io~1cluster-api-autoscaler-node-group-min-size",
 					Value:     "1",
+				},
+				{
+					Operation: "replace",
+					Path:      "/metadata/labels/cluster.x-k8s.io~1cluster-name",
+					Value:     "",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/minReadySeconds",
+					Value:     float64(0),
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/replicas",
+					Value:     float64(1),
 				},
 			},
 			errorMatcher: nil,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15570

This PR adds support for CAPI/CAPZ defaulting on all resources that support it. The patches are automatically generated based on the differences in the resources from before to after applying the defaults.

There are some messages below that hopefully explain my logic.