### PR TITLE
Don't validate the 'spec.networkSpec.subnets' field of 'AzureCluster' resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Execute CAPZ validation for all resources.
+- Execute CAPI/CAPZ validation for all resources.
+
+### Remove
+
+- Don't execute CAPI/CAPZ validation for the `subnet` fields of the `AzureCluster` resource.
 
 ## [2.2.0] - 2021-02-05
 

--- a/pkg/azurecluster/validate_create.go
+++ b/pkg/azurecluster/validate_create.go
@@ -60,6 +60,7 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 
 	err := azureClusterCR.ValidateCreate()
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
+	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -55,6 +55,7 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 
 	err := azureClusterNewCR.ValidateUpdate(azureClusterOldCR)
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
+	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
For solving the problem found here https://gigantic.slack.com/archives/CNUDS3AMU/p1613459439057600

Currently, subnets are added to the `AzureCluster` CRs by `AzureMachinePool` CRs via `azure-operator`, which goes against the validation logic in here.