### PR TITLE
Remove 'control-plane' subnet defaulting from AzureCluster CRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Remove
 
 - Don't execute CAPI/CAPZ validation for the `subnet` and `spec.subscriptionID` fields of the `AzureCluster` resource.
+- Remove defaulting for the `AzureCluster` `control-plane` subnet.
 
 ## [2.2.0] - 2021-02-05
 

--- a/integration/test/createnodepool/testdata/2-azurecluster.yaml
+++ b/integration/test/createnodepool/testdata/2-azurecluster.yaml
@@ -16,8 +16,6 @@ spec:
   location: westeurope
   networkSpec:
     subnets:
-      - name: 2mw4b-VirtualNetwork-MasterSubnet
-        role: control-plane
       - cidrBlocks:
           - 10.11.3.0/24
         id: /subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/2mw4b/providers/Microsoft.Network/virtualNetworks/2mw4b-VirtualNetwork/subnets/2mw4b

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -88,14 +88,6 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = m.ensureControlPlaneSubnet(ctx, azureClusterCR)
-	if err != nil {
-		return []mutator.PatchOperation{}, microerror.Mask(err)
-	}
-	if patch != nil {
-		result = append(result, *patch)
-	}
-
 	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
@@ -168,28 +160,6 @@ func (m *UpdateMutator) ensureAPIServerLBFrontendIPs(ctx context.Context, azureC
 		}
 
 		return mutator.PatchAdd("/spec/networkSpec/apiServerLB/frontendIPs", frontendIPs), nil
-	}
-
-	return nil, nil
-}
-
-func (m *UpdateMutator) ensureControlPlaneSubnet(ctx context.Context, azureCluster *capzv1alpha3.AzureCluster) (*mutator.PatchOperation, error) {
-	hasControlPlaneSubnet := false
-	for _, subnet := range azureCluster.Spec.NetworkSpec.Subnets {
-		if subnet.Role == capzv1alpha3.SubnetControlPlane {
-			hasControlPlaneSubnet = true
-			break
-		}
-	}
-
-	if !hasControlPlaneSubnet {
-		subnets := azureCluster.Spec.NetworkSpec.Subnets[:]
-		subnets = append(subnets, &capzv1alpha3.SubnetSpec{
-			Role: capzv1alpha3.SubnetControlPlane,
-			Name: key.MasterSubnetName(azureCluster.Name),
-		})
-
-		return mutator.PatchAdd("/spec/networkSpec/subnets", subnets), nil
 	}
 
 	return nil, nil


### PR DESCRIPTION
Since we already skipped validation for the subnets, we can remove this default. It was causing panics in the older `azure-operator` versions anyway.