### PR TITLE
Skip 'azureCluster.spec.networkSpec.apiServerLB' validation on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Skipping validation for the `azureCluster.spec.networkSpec.apiServerLB` on update.
+
 ## [2.3.1] - 2021-02-23
 
 ### Changed

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -110,7 +110,7 @@ func IgnoreCAPIErrorForField(field string, err error) error {
 		var causes []metav1.StatusCause
 		{
 			for _, cause := range errStatus.Details.Causes {
-				if cause.Field != field {
+				if strings.HasPrefix(cause.Field, field) {
 					causes = append(causes, cause)
 				}
 			}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -110,7 +110,7 @@ func IgnoreCAPIErrorForField(field string, err error) error {
 		var causes []metav1.StatusCause
 		{
 			for _, cause := range errStatus.Details.Causes {
-				if strings.HasPrefix(cause.Field, field) {
+				if !strings.HasPrefix(cause.Field, field) {
 					causes = append(causes, cause)
 				}
 			}

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -56,6 +56,7 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	err := azureClusterNewCR.ValidateUpdate(azureClusterOldCR)
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
 	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
+	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.apiServerLB", err)
 	err = errors.IgnoreCAPIErrorForField("spec.SubscriptionID", err)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -56,6 +56,7 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	err := azureClusterNewCR.ValidateUpdate(azureClusterOldCR)
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
 	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
+	// TODO(axbarsan): Remove this once all the older clusters have it.
 	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.apiServerLB", err)
 	err = errors.IgnoreCAPIErrorForField("spec.SubscriptionID", err)
 	if err != nil {


### PR DESCRIPTION
This validation doesn't let us change this field on update.

Since we default this field on existing clusters that might not have it (some clusters have been created with an older version of the `AzureCluster` CR and don't have this field), let's skip validation for now (at least until all clusters have been updated with the new value).