### PR TITLE
Skipping all validation and defaulting for CAPI releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Skipping all validation and defaulting for resources with CAPI release label
+
 ## [2.3.2] - 2021-02-23
 
 ### Changed

--- a/pkg/azurecluster/mutate_create.go
+++ b/pkg/azurecluster/mutate_create.go
@@ -68,6 +68,14 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(azureClusterCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := m.ensureControlPlaneEndpointHost(ctx, azureClusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -54,6 +54,14 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(azureClusterCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := ensureAPIServerLB(azureClusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/azurecluster/validate_create.go
+++ b/pkg/azurecluster/validate_create.go
@@ -58,7 +58,15 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
-	err := azureClusterCR.ValidateCreate()
+	capi, err := generic.IsCAPIRelease(azureClusterCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = azureClusterCR.ValidateCreate()
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
 	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
 	err = errors.IgnoreCAPIErrorForField("spec.SubscriptionID", err)

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -53,7 +53,15 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
-	err := azureClusterNewCR.ValidateUpdate(azureClusterOldCR)
+	capi, err := generic.IsCAPIRelease(azureClusterNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = azureClusterNewCR.ValidateUpdate(azureClusterOldCR)
 	err = errors.IgnoreCAPIErrorForField("metadata.Name", err)
 	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.subnets", err)
 	// TODO(axbarsan): Remove this once all the older clusters have it.

--- a/pkg/azuremachine/mutate_create.go
+++ b/pkg/azuremachine/mutate_create.go
@@ -60,6 +60,14 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(azureMachineCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := m.ensureLocation(ctx, azureMachineCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/azuremachine/validate_create.go
+++ b/pkg/azuremachine/validate_create.go
@@ -59,7 +59,15 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 
-	err := cr.ValidateCreate()
+	capi, err := generic.IsCAPIRelease(cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = cr.ValidateCreate()
 	err = errors.IgnoreCAPIErrorForField("sshPublicKey", err)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/azuremachine/validate_update.go
+++ b/pkg/azuremachine/validate_update.go
@@ -52,7 +52,15 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachine CR: %v", err)
 	}
 
-	err := azureMachineNewCR.ValidateUpdate(azureMachineOldCR)
+	capi, err := generic.IsCAPIRelease(azureMachineNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = azureMachineNewCR.ValidateUpdate(azureMachineOldCR)
 	err = errors.IgnoreCAPIErrorForField("sshPublicKey", err)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/azuremachinepool/mutate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/mutate_azuremachinepool_create.go
@@ -67,6 +67,14 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(azureMPCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := m.ensureLocation(ctx, azureMPCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/azuremachinepool/mutate_update.go
+++ b/pkg/azuremachinepool/mutate_update.go
@@ -10,6 +10,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
@@ -51,6 +52,14 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMPCR := &expcapzv1alpha3.AzureMachinePool{}
 	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureMPCR); err != nil {
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
+	}
+
+	capi, err := generic.IsCAPIRelease(azureMPCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
 	}
 
 	azureMPCR.Default()

--- a/pkg/azuremachinepool/validate_azuremachinepool_create.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_create.go
@@ -58,7 +58,15 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
-	err := azureMPNewCR.ValidateCreate()
+	capi, err := generic.IsCAPIRelease(azureMPNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = azureMPNewCR.ValidateCreate()
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azuremachinepool/validate_azuremachinepool_update.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update.go
@@ -49,7 +49,15 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
-	err := azureMPNewCR.ValidateUpdate(azureMPOldCR)
+	capi, err := generic.IsCAPIRelease(azureMPNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = azureMPNewCR.ValidateUpdate(azureMPOldCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -62,6 +62,14 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(clusterCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := m.ensureClusterNetwork(ctx, clusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -54,6 +54,14 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(clusterCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	patch, err := generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)

--- a/pkg/cluster/validate_create.go
+++ b/pkg/cluster/validate_create.go
@@ -52,7 +52,15 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
-	err := clusterCR.ValidateCreate()
+	capi, err := generic.IsCAPIRelease(clusterCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = clusterCR.ValidateCreate()
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/cluster/validate_update.go
+++ b/pkg/cluster/validate_update.go
@@ -56,7 +56,15 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
-	err := clusterNewCR.ValidateUpdate(clusterOldCR)
+	capi, err := generic.IsCAPIRelease(clusterNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = clusterNewCR.ValidateUpdate(clusterOldCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/generic/capi.go
+++ b/pkg/generic/capi.go
@@ -1,0 +1,45 @@
+package generic
+
+import (
+	"strings"
+
+	"github.com/giantswarm/apiextensions/v2/pkg/label"
+	"github.com/giantswarm/microerror"
+
+	"github.com/blang/semver"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// FirstCAPIRelease is the first GS release that runs on CAPI controllers
+	FirstCAPIRelease = "20.0.0-v1alpha3"
+)
+
+func IsCAPIRelease(meta metav1.Object) (bool, error) {
+	if meta.GetLabels()[label.ReleaseVersion] == "" {
+		return false, nil
+	}
+	releaseVersion, err := ReleaseVersion(meta)
+	if err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to parse release version from object")
+	}
+	return IsCAPIVersion(releaseVersion)
+}
+
+// IsCAPIVersion returns whether a given releaseVersion is using CAPI controllers
+func IsCAPIVersion(releaseVersion *semver.Version) (bool, error) {
+	CAPIVersion, err := semver.New(FirstCAPIRelease)
+	if err != nil {
+		return false, microerror.Maskf(parsingFailedError, "unable to get first CAPI release version")
+	}
+	return releaseVersion.GE(*CAPIVersion), nil
+}
+
+func ReleaseVersion(meta metav1.Object) (*semver.Version, error) {
+	version, ok := meta.GetLabels()[label.ReleaseVersion]
+	if !ok {
+		return nil, microerror.Maskf(parsingFailedError, "unable to get release version from Object %s", meta.GetName())
+	}
+	version = strings.TrimPrefix(version, "v")
+	return semver.New(version)
+}

--- a/pkg/generic/capi_test.go
+++ b/pkg/generic/capi_test.go
@@ -1,0 +1,63 @@
+package generic
+
+import (
+	"context"
+	"strconv"
+	"testing"
+)
+
+func TestCAPIReleaseLabel(t *testing.T) {
+	testCases := []struct {
+		ctx  context.Context
+		name string
+
+		currentRelease string
+		expectedResult bool
+	}{
+		{
+			// Release label is not set
+			name: "case 0",
+			ctx:  context.Background(),
+
+			currentRelease: "",
+			expectedResult: false,
+		},
+		{
+			// CAPI Release label is set
+			name: "case 1",
+			ctx:  context.Background(),
+
+			currentRelease: "20.0.0-v1alpha3",
+			expectedResult: true,
+		},
+		{
+			// CAPI Release label is set
+			name: "case 2",
+			ctx:  context.Background(),
+
+			currentRelease: "20.0.0",
+			expectedResult: true,
+		},
+		{
+			// GS Release label is set
+			name: "case 3",
+			ctx:  context.Background(),
+
+			currentRelease: "14.0.0",
+			expectedResult: false,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			object := newObjectWithRelease(nil, &tc.currentRelease)
+			capi, err := IsCAPIRelease(object)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// check if the result label is as expected
+			if tc.expectedResult != capi {
+				t.Fatalf("expected %v to be equal to %v", tc.expectedResult, capi)
+			}
+		})
+	}
+}

--- a/pkg/generic/error.go
+++ b/pkg/generic/error.go
@@ -84,3 +84,12 @@ var componentNotFoundInReleaseError = &microerror.Error{
 func IsComponentNotFoundInReleaseError(err error) bool {
 	return microerror.Cause(err) == componentNotFoundInReleaseError
 }
+
+var parsingFailedError = &microerror.Error{
+	Kind: "parsingFailedError",
+}
+
+// IsParsingFailed asserts parsingFailedError.
+func IsParsingFailed(err error) bool {
+	return microerror.Cause(err) == parsingFailedError
+}

--- a/pkg/machinepool/mutate_machinepool_create.go
+++ b/pkg/machinepool/mutate_machinepool_create.go
@@ -53,6 +53,14 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse MachinePool CR: %v", err)
 	}
 
+	capi, err := generic.IsCAPIRelease(machinePoolCR)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
+	}
+	if capi {
+		return []mutator.PatchOperation{}, nil
+	}
+
 	defaultSpecValues := setDefaultSpecValues(m, machinePoolCR)
 	if defaultSpecValues != nil {
 		result = append(result, defaultSpecValues...)

--- a/pkg/machinepool/validate_machinepool_create.go
+++ b/pkg/machinepool/validate_machinepool_create.go
@@ -53,7 +53,15 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
-	err := machinePoolNewCR.ValidateCreate()
+	capi, err := generic.IsCAPIRelease(machinePoolNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = machinePoolNewCR.ValidateCreate()
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/machinepool/validate_machinepool_update.go
+++ b/pkg/machinepool/validate_machinepool_update.go
@@ -43,7 +43,15 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
-	err := machinePoolNewCR.ValidateUpdate(machinePoolOldCR)
+	capi, err := generic.IsCAPIRelease(machinePoolNewCR)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if capi {
+		return nil
+	}
+
+	err = machinePoolNewCR.ValidateUpdate(machinePoolOldCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16119

For now we want to skip all the validation and defaulting for releases that run solely on CAPI controllers.
Based on https://github.com/giantswarm/aws-admission-controller/pull/198