### PR TITLE
Don't validate CRs when they are being deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Don't validate objects if they are being deleted.
+
 ### Added
 
 - Skipping all validation and defaulting for resources with CAPI release label

--- a/internal/test/azurecluster/builder.go
+++ b/internal/test/azurecluster/builder.go
@@ -56,6 +56,14 @@ func ControlPlaneEndpoint(controlPlaneEndpointHost string, controlPlaneEndpointP
 	}
 }
 
+func WithDeletionTimestamp() BuilderOption {
+	return func(azureCluster *capzv1alpha3.AzureCluster) *capzv1alpha3.AzureCluster {
+		now := metav1.Now()
+		azureCluster.ObjectMeta.SetDeletionTimestamp(&now)
+		return azureCluster
+	}
+}
+
 func BuildAzureCluster(opts ...BuilderOption) *capzv1alpha3.AzureCluster {
 	clusterName := test.GenerateName()
 	azureCluster := &capzv1alpha3.AzureCluster{

--- a/internal/test/azuremachinepool/builder.go
+++ b/internal/test/azuremachinepool/builder.go
@@ -82,6 +82,14 @@ func VMSize(vmsize string) BuilderOption {
 	}
 }
 
+func WithDeletionTimestamp() BuilderOption {
+	return func(azureMachinePool *expcapzv1alpha3.AzureMachinePool) *expcapzv1alpha3.AzureMachinePool {
+		now := metav1.Now()
+		azureMachinePool.ObjectMeta.SetDeletionTimestamp(&now)
+		return azureMachinePool
+	}
+}
+
 func BuildAzureMachinePool(opts ...BuilderOption) *expcapzv1alpha3.AzureMachinePool {
 	nodepoolName := test.GenerateName()
 	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{

--- a/internal/test/cluster/builder.go
+++ b/internal/test/cluster/builder.go
@@ -31,6 +31,22 @@ func Labels(labels map[string]string) BuilderOption {
 	}
 }
 
+func ControlPlaneEndpoint(controlPlaneEndpointHost string, controlPlaneEndpointPort int32) BuilderOption {
+	return func(cluster *capiv1alpha3.Cluster) *capiv1alpha3.Cluster {
+		cluster.Spec.ControlPlaneEndpoint.Host = controlPlaneEndpointHost
+		cluster.Spec.ControlPlaneEndpoint.Port = controlPlaneEndpointPort
+		return cluster
+	}
+}
+
+func WithDeletionTimestamp() BuilderOption {
+	return func(cluster *capiv1alpha3.Cluster) *capiv1alpha3.Cluster {
+		now := metav1.Now()
+		cluster.ObjectMeta.SetDeletionTimestamp(&now)
+		return cluster
+	}
+}
+
 func BuildCluster(opts ...BuilderOption) *capiv1alpha3.Cluster {
 	clusterName := test.GenerateName()
 	cluster := &capiv1alpha3.Cluster{

--- a/internal/test/machinepool/builder.go
+++ b/internal/test/machinepool/builder.go
@@ -66,6 +66,14 @@ func Annotation(name, val string) BuilderOption {
 	}
 }
 
+func WithDeletionTimestamp() BuilderOption {
+	return func(machinePool *expcapiv1alpha3.MachinePool) *expcapiv1alpha3.MachinePool {
+		now := metav1.Now()
+		machinePool.ObjectMeta.SetDeletionTimestamp(&now)
+		return machinePool
+	}
+}
+
 func BuildMachinePool(opts ...BuilderOption) *expcapiv1alpha3.MachinePool {
 	nodepoolName := test.GenerateName()
 	machinePool := &expcapiv1alpha3.MachinePool{

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -53,6 +53,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
 	}
 
+	if !azureClusterNewCR.GetDeletionTimestamp().IsZero() {
+		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		return nil
+	}
+
 	capi, err := generic.IsCAPIRelease(azureClusterNewCR)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/azurecluster/validate_update_test.go
+++ b/pkg/azurecluster/validate_update_test.go
@@ -40,6 +40,12 @@ func TestAzureClusterUpdateValidate(t *testing.T) {
 			newAzureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher:    IsControlPlaneEndpointWasChangedError,
 		},
+		{
+			name:            "case 2: port changed but object is being deleted",
+			oldAzureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443)),
+			newAzureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80), builder.WithDeletionTimestamp()),
+			errorMatcher:    nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/azuremachinepool/validate_azuremachinepool_update.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update.go
@@ -49,6 +49,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
 	}
 
+	if !azureMPNewCR.GetDeletionTimestamp().IsZero() {
+		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		return nil
+	}
+
 	capi, err := generic.IsCAPIRelease(azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
+++ b/pkg/azuremachinepool/validate_azuremachinepool_update_test.go
@@ -173,6 +173,12 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capzv1alpha3.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
 			errorMatcher: nil,
 		},
+		{
+			name:         "case 21: changed location but object is being deleted",
+			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("westeurope")),
+			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("northeastitaly"), builder.WithDeletionTimestamp()),
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cluster/validate_update.go
+++ b/pkg/cluster/validate_update.go
@@ -56,6 +56,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
 	}
 
+	if !clusterNewCR.GetDeletionTimestamp().IsZero() {
+		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		return nil
+	}
+
 	capi, err := generic.IsCAPIRelease(clusterNewCR)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/cluster/validate_update_test.go
+++ b/pkg/cluster/validate_update_test.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	builder "github.com/giantswarm/azure-admission-controller/internal/test/cluster"
 )
 
 func TestClusterUpdateValidate(t *testing.T) {
@@ -111,6 +113,12 @@ func TestClusterUpdateValidate(t *testing.T) {
 				nil,
 			),
 			errorMatcher: IsClusterNetworkWasChangedError,
+		},
+		{
+			name:         "case 7: host changed but object is being deleted",
+			oldCluster:   builder.BuildClusterAsJson(builder.Name("ab123"), builder.WithDeletionTimestamp(), builder.ControlPlaneEndpoint("api.ab123.test.westeurope.azure.gigantic.io", 443)),
+			newCluster:   builder.BuildClusterAsJson(builder.Name("ab123"), builder.WithDeletionTimestamp(), builder.ControlPlaneEndpoint("api.azure.gigantic.io", 443)),
+			errorMatcher: nil,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/machinepool/validate_machinepool_update.go
+++ b/pkg/machinepool/validate_machinepool_update.go
@@ -43,6 +43,11 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
 	}
 
+	if !machinePoolNewCR.GetDeletionTimestamp().IsZero() {
+		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		return nil
+	}
+
 	capi, err := generic.IsCAPIRelease(machinePoolNewCR)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/machinepool/validate_machinepool_update_test.go
+++ b/pkg/machinepool/validate_machinepool_update_test.go
@@ -34,6 +34,12 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"2"})),
 			errorMatcher: IsFailureDomainWasChangedError,
 		},
+		{
+			name:         "case 2: FailureDomains changed but object is being deleted",
+			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1"})),
+			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"2"}), builder.WithDeletionTimestamp()),
+			errorMatcher: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When developing, sometimes it's a pain in the ass to delete resources because the admission controller gets in the way (i.e the `Release` CR no longer exists).
So let's disable validation when deleting some CR's.