### PR TITLE
Move labels mutator functions to pkg/mutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When importing `sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3` use `capz` as package alias.
 - When importing `sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3` use `capzexp` as package alias.
 - Remove package names from some file names.
+- Move labels mutator functions to `pkg/mutator`.
 
 ## [2.7.0] - 2021-05-19
 

--- a/pkg/azurecluster/mutate_create.go
+++ b/pkg/azurecluster/mutate_create.go
@@ -108,7 +108,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -70,7 +70,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -78,7 +78,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, azureClusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/azuremachine/mutate_create.go
+++ b/pkg/azuremachine/mutate_create.go
@@ -84,7 +84,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, azureMachineCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, azureMachineCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/azuremachinepool/mutate_create.go
+++ b/pkg/azuremachinepool/mutate_create.go
@@ -99,7 +99,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.EnsureReleaseVersionLabel(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
+	patch, err = mutator.EnsureReleaseVersionLabel(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -107,7 +107,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -94,7 +94,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, clusterCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, clusterCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -62,7 +62,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, nil
 	}
 
-	patch, err := generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err := mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -70,7 +70,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlClient, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/generic/capi_test.go
+++ b/pkg/generic/capi_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strconv"
 	"testing"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCAPIReleaseLabel(t *testing.T) {
@@ -60,4 +63,29 @@ func TestCAPIReleaseLabel(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newObjectWithRelease(clusterID *string, release *string) metav1.Object {
+	obj := &GenericObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ab123",
+			Namespace: "default",
+			Labels: map[string]string{
+				"azure-operator.giantswarm.io/version": "5.0.0",
+				"cluster.x-k8s.io/cluster-name":        "ab123",
+				"cluster.x-k8s.io/control-plane":       "true",
+				"giantswarm.io/machine-pool":           "ab123",
+			},
+		},
+	}
+
+	if clusterID != nil {
+		obj.Labels[label.Cluster] = *clusterID
+	}
+
+	if release != nil {
+		obj.Labels[label.ReleaseVersion] = *release
+	}
+
+	return obj
 }

--- a/pkg/machinepool/mutate_create.go
+++ b/pkg/machinepool/mutate_create.go
@@ -66,7 +66,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, defaultSpecValues...)
 	}
 
-	patch, err := generic.EnsureReleaseVersionLabel(ctx, m.ctrlClient, machinePoolCR.GetObjectMeta())
+	patch, err := mutator.EnsureReleaseVersionLabel(ctx, m.ctrlClient, machinePoolCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -74,7 +74,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = generic.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, machinePoolCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, machinePoolCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/mutator/common_test.go
+++ b/pkg/mutator/common_test.go
@@ -1,0 +1,10 @@
+package mutator
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type GenericObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+}

--- a/pkg/mutator/component_version_label.go
+++ b/pkg/mutator/component_version_label.go
@@ -1,4 +1,4 @@
-package generic
+package mutator
 
 import (
 	"context"
@@ -9,11 +9,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/azure-admission-controller/pkg/release"
 )
 
-func CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx context.Context, ctrlClient client.Client, meta metav1.Object) (*mutator.PatchOperation, error) {
+func CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx context.Context, ctrlClient client.Client, meta metav1.Object) (*PatchOperation, error) {
 	if meta.GetLabels()[label.AzureOperatorVersion] == "" {
 		azureOperatorVersion, err := getLabelValueFromAzureCluster(ctx, ctrlClient, meta, label.AzureOperatorVersion)
 		if err != nil {
@@ -24,13 +23,13 @@ func CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx context.Context, ctrlCl
 			return nil, microerror.Maskf(azureOperatorVersionLabelNotFoundError, "Cannot find label %#q in AzureCluster CR. Can't continue.", label.AzureOperatorVersion)
 		}
 
-		return mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(label.AzureOperatorVersion)), azureOperatorVersion), nil
+		return PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(label.AzureOperatorVersion)), azureOperatorVersion), nil
 	}
 
 	return nil, nil
 }
 
-func EnsureComponentVersionLabelFromRelease(ctx context.Context, ctrlClient client.Client, meta metav1.Object, componentName string, labelName string) (*mutator.PatchOperation, error) {
+func EnsureComponentVersionLabelFromRelease(ctx context.Context, ctrlClient client.Client, meta metav1.Object, componentName string, labelName string) (*PatchOperation, error) {
 	var releaseVersion = meta.GetLabels()[label.ReleaseVersion]
 	if releaseVersion == "" {
 		return nil, microerror.Maskf(releaseLabelNotFoundError, "Cannot find label %#q in CR. Can't continue.", label.ReleaseVersion)
@@ -46,7 +45,7 @@ func EnsureComponentVersionLabelFromRelease(ctx context.Context, ctrlClient clie
 	}
 
 	if meta.GetLabels()[labelName] != componentVersions[componentName] {
-		return mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(labelName)), componentVersions[componentName]), nil
+		return PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(labelName)), componentVersions[componentName]), nil
 	}
 
 	return nil, nil

--- a/pkg/mutator/component_version_label_test.go
+++ b/pkg/mutator/component_version_label_test.go
@@ -1,4 +1,4 @@
-package generic
+package mutator
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -20,13 +19,13 @@ func Test_EnsureComponentVersionLabel(t *testing.T) {
 	testCases := []struct {
 		name         string
 		meta         metav1.Object
-		patch        *mutator.PatchOperation
+		patch        *PatchOperation
 		errorMatcher func(error) bool
 	}{
 		{
 			name: "case 0: azure operator label missing",
 			meta: newObjectWithLabels(to.StringPtr("ab123"), nil),
-			patch: &mutator.PatchOperation{
+			patch: &PatchOperation{
 				Operation: "add",
 				Path:      "/metadata/labels/azure-operator.giantswarm.io~1version",
 				Value:     "5.0.0",

--- a/pkg/mutator/ensure_release_label.go
+++ b/pkg/mutator/ensure_release_label.go
@@ -1,4 +1,4 @@
-package generic
+package mutator
 
 import (
 	"context"
@@ -13,10 +13,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-func EnsureReleaseVersionLabel(ctx context.Context, ctrlClient client.Client, meta metav1.Object) (*mutator.PatchOperation, error) {
+func EnsureReleaseVersionLabel(ctx context.Context, ctrlClient client.Client, meta metav1.Object) (*PatchOperation, error) {
 	if meta.GetLabels()[label.ReleaseVersion] == "" {
 		release, err := getReleaseLabelValueFromAzureCluster(ctx, ctrlClient, meta)
 		if err != nil {
@@ -26,7 +25,7 @@ func EnsureReleaseVersionLabel(ctx context.Context, ctrlClient client.Client, me
 			return nil, microerror.Maskf(releaseLabelNotFoundError, "AzureCluster did not have the %#q label set. Can't continue.", label.ReleaseVersion)
 		}
 
-		return mutator.PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(label.ReleaseVersion)), release), nil
+		return PatchAdd(fmt.Sprintf("/metadata/labels/%s", escapeJSONPatchString(label.ReleaseVersion)), release), nil
 	}
 
 	return nil, nil

--- a/pkg/mutator/ensure_release_label_test.go
+++ b/pkg/mutator/ensure_release_label_test.go
@@ -1,4 +1,4 @@
-package generic
+package mutator
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
@@ -21,7 +20,7 @@ func Test_EnsureReleaseLabel(t *testing.T) {
 	testCases := []struct {
 		name         string
 		meta         metav1.Object
-		patch        *mutator.PatchOperation
+		patch        *PatchOperation
 		errorMatcher func(error) bool
 	}{
 		{
@@ -51,7 +50,7 @@ func Test_EnsureReleaseLabel(t *testing.T) {
 		{
 			name: "case 4: release wasn't set, cluster CR found, release label present",
 			meta: newObjectWithRelease(to.StringPtr("ab123"), nil),
-			patch: &mutator.PatchOperation{
+			patch: &PatchOperation{
 				Operation: "add",
 				Path:      "/metadata/labels/release.giantswarm.io~1version",
 				Value:     "13.0.0",

--- a/pkg/mutator/error.go
+++ b/pkg/mutator/error.go
@@ -1,0 +1,41 @@
+package mutator
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var azureOperatorVersionLabelNotFoundError = &microerror.Error{
+	Kind: "azureOperatorVersionLabelNotFoundError",
+}
+
+// IsAzureOperatorVersionLabelNotFoundError asserts azureOperatorVersionLabelNotFoundError.
+func IsAzureOperatorVersionLabelNotFoundError(err error) bool {
+	return microerror.Cause(err) == azureOperatorVersionLabelNotFoundError
+}
+
+var clusterLabelNotFoundError = &microerror.Error{
+	Kind: "clusterLabelNotFoundError",
+}
+
+// IsClusterLabelNotFoundError asserts clusterLabelNotFoundError.
+func IsClusterLabelNotFoundError(err error) bool {
+	return microerror.Cause(err) == clusterLabelNotFoundError
+}
+
+var componentNotFoundInReleaseError = &microerror.Error{
+	Kind: "componentNotFoundInReleaseError",
+}
+
+// IsComponentNotFoundInReleaseError asserts componentNotFoundInReleaseError.
+func IsComponentNotFoundInReleaseError(err error) bool {
+	return microerror.Cause(err) == componentNotFoundInReleaseError
+}
+
+var releaseLabelNotFoundError = &microerror.Error{
+	Kind: "releaseLabelNotFoundError",
+}
+
+// IsReleaseLabelNotFoundError asserts releaseLabelNotFoundError.
+func IsReleaseLabelNotFoundError(err error) bool {
+	return microerror.Cause(err) == releaseLabelNotFoundError
+}

--- a/pkg/spark/mutate_create.go
+++ b/pkg/spark/mutate_create.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
@@ -53,7 +52,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		return []mutator.PatchOperation{}, microerror.Maskf(errors.ParsingFailedError, "unable to parse Spark CR: %v", err)
 	}
 
-	patch, err := generic.EnsureReleaseVersionLabel(ctx, m.ctrlClient, sparkCR.GetObjectMeta())
+	patch, err := mutator.EnsureReleaseVersionLabel(ctx, m.ctrlClient, sparkCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}


### PR DESCRIPTION
Coming from https://github.com/giantswarm/azure-admission-controller/pull/216#issuecomment-841073290

## Motivation

Changes in https://github.com/giantswarm/azure-admission-controller/pull/216 require some package refactoring. This PR contains some of those.

## What's in the box

- Moved `component_version_label.go` and `component_version_label_test.go` from `pkg/generic` to `pkg/mutator`
- Moved `ensure_release_label.go` and `ensure_release_label_test.go` from `pkg/generic` to `pkg/mutator`
- Moving these two also required duplicating few simple helper interfaces, types and functions