### PR TITLE
Add WebhookHandler types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When importing `sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3` use `capzexp` as package alias.
 - Remove package names from some file names.
 - Move labels mutator functions to `pkg/mutator`.
+- Add new `WebhookHandler` interfaces for validation and mutation.
 
 ## [2.7.0] - 2021-05-19
 

--- a/pkg/generic/types.go
+++ b/pkg/generic/types.go
@@ -1,0 +1,14 @@
+package generic
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Decoder interface {
+	Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error)
+}
+
+type Logger interface {
+	Log(keyVals ...interface{})
+}

--- a/pkg/mutator/webhook_handler.go
+++ b/pkg/mutator/webhook_handler.go
@@ -1,0 +1,23 @@
+package mutator
+
+import (
+	"context"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+)
+
+type WebhookHandlerBase interface {
+	generic.Decoder
+	generic.Logger
+	Resource() string
+}
+
+type WebhookCreateHandler interface {
+	WebhookHandlerBase
+	OnCreateMutate(ctx context.Context, object interface{}) ([]PatchOperation, error)
+}
+
+type WebhookUpdateHandler interface {
+	WebhookHandlerBase
+	OnUpdateMutate(ctx context.Context, oldObject interface{}, object interface{}) ([]PatchOperation, error)
+}

--- a/pkg/validator/webhook_handler.go
+++ b/pkg/validator/webhook_handler.go
@@ -1,0 +1,22 @@
+package validator
+
+import (
+	"context"
+
+	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+)
+
+type WebhookHandlerBase interface {
+	generic.Decoder
+	generic.Logger
+}
+
+type WebhookCreateHandler interface {
+	WebhookHandlerBase
+	OnCreateValidate(ctx context.Context, object interface{}) error
+}
+
+type WebhookUpdateHandler interface {
+	WebhookHandlerBase
+	OnUpdateValidate(ctx context.Context, oldObject interface{}, object interface{}) error
+}


### PR DESCRIPTION
Coming from https://github.com/giantswarm/azure-admission-controller/pull/216#issuecomment-841073290

## Motivation

https://github.com/giantswarm/azure-admission-controller/pull/216 introduces a breaking change where all mutators and validators are merged into a single `WebhookHandler` per CRD. That breaking change then propagates through the entire `azure-admission-controller`, it requires updates in tests and main for example.

This PR only introduces new `WebhookHandler` interfaces for the sake of easier reviewing, without actually using them anywhere.

## What's in the box

- `validator.WebhookCreateHandler` interface for validating `create` requests
- `validator.WebhookUpdateHandler` interface for validating `update` requests
- `mutator.WebhookCreateHandler` interface for mutating `create` requests
- `mutator.WebhookUpdateHandler` interfaces for mutating `update` requests
- `generic.Decoder` interface to abstract away CR decoding from the admission request
- `Logger` cause we log a lot :)

The interfaces are intentionally split so that there is one for every validate/mutate + verb combination. This way we can only implement webhooks that we really need (YAGNI :slightly_smiling_face:).