### PR TITLE
Add cluster.WebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Release is considered to be "legacy" if it contains azure-operator.
 - Unit tests for functions from `release` package.
 - `HttpHandlerFactory` for creating HTTP handlers that are using new webhook handlers.
+- Cluster webhook handler that replaces mutators and validators.
 
 ### Changed
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -148,3 +148,12 @@ func IgnoreCAPIErrorForField(field string, err error) error {
 
 	return err
 }
+
+var WrongTypeError = &microerror.Error{
+	Kind: "WrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == WrongTypeError
+}

--- a/main.go
+++ b/main.go
@@ -422,6 +422,7 @@ func mainError() error {
 	{
 		c := validator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
+			CtrlCache: ctrlCache,
 		}
 		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -422,7 +422,7 @@ func mainError() error {
 	{
 		c := validator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
-			CtrlCache: ctrlCache,
+			CtrlCache:  ctrlCache,
 		}
 		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -434,6 +434,7 @@ func mainError() error {
 	{
 		c := mutator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
+			CtrlCache:  ctrlCache,
 		}
 		mutatorHttpHandlerFactory, err = mutator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/pkg/cluster/mutate_create.go
+++ b/pkg/cluster/mutate_create.go
@@ -5,72 +5,22 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
 	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type CreateMutator struct {
-	baseDomain string
-	ctrlClient client.Client
-	logger     micrologger.Logger
-}
-
-type CreateMutatorConfig struct {
-	BaseDomain string
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-}
-
-func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
-	if config.BaseDomain == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
-	}
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	v := &CreateMutator{
-		baseDomain: config.BaseDomain,
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return v, nil
-}
-
-func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnCreateMutate(ctx context.Context, object interface{}) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	clusterCR := &capi.Cluster{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, clusterCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(clusterCR)
+	clusterCR, err := key.ToClusterPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
+	clusterCROriginal := clusterCR.DeepCopy()
 
-	patch, err := m.ensureClusterNetwork(ctx, clusterCR)
+	patch, err := h.ensureClusterNetwork(ctx, clusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -78,7 +28,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = m.ensureControlPlaneEndpointHost(ctx, clusterCR)
+	patch, err = h.ensureControlPlaneEndpointHost(ctx, clusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -86,7 +36,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = m.ensureControlPlaneEndpointPort(ctx, clusterCR)
+	patch, err = h.ensureControlPlaneEndpointPort(ctx, clusterCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -94,7 +44,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, clusterCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, h.ctrlClient, clusterCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -105,7 +55,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	clusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, clusterCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(clusterCROriginal, clusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -116,15 +66,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	return result, nil
 }
 
-func (m *CreateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *CreateMutator) Resource() string {
-	return "cluster"
-}
-
-func (m *CreateMutator) ensureClusterNetwork(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureClusterNetwork(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
 	// Ensure ClusterNetwork is set.
 	if clusterCR.Spec.ClusterNetwork == nil {
 		clusterNetwork := capi.ClusterNetwork{
@@ -143,15 +85,15 @@ func (m *CreateMutator) ensureClusterNetwork(ctx context.Context, clusterCR *cap
 	return nil, nil
 }
 
-func (m *CreateMutator) ensureControlPlaneEndpointHost(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureControlPlaneEndpointHost(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
 	if clusterCR.Spec.ControlPlaneEndpoint.Host == "" {
-		return mutator.PatchAdd("/spec/controlPlaneEndpoint/host", key.GetControlPlaneEndpointHost(clusterCR.Name, m.baseDomain)), nil
+		return mutator.PatchAdd("/spec/controlPlaneEndpoint/host", key.GetControlPlaneEndpointHost(clusterCR.Name, h.baseDomain)), nil
 	}
 
 	return nil, nil
 }
 
-func (m *CreateMutator) ensureControlPlaneEndpointPort(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureControlPlaneEndpointPort(ctx context.Context, clusterCR *capi.Cluster) (*mutator.PatchOperation, error) {
 	if clusterCR.Spec.ControlPlaneEndpoint.Port == 0 {
 		return mutator.PatchAdd("/spec/controlPlaneEndpoint/port", key.ControlPlaneEndpointPort), nil
 	}

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -19,7 +19,7 @@ func (h *WebhookHandler) OnUpdateMutate(ctx context.Context, _ interface{}, obje
 	}
 	clusterCROriginal := clusterCR.DeepCopy()
 
-	patch, err := mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err := mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlReader, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -27,7 +27,7 @@ func (h *WebhookHandler) OnUpdateMutate(ctx context.Context, _ interface{}, obje
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlReader, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}

--- a/pkg/cluster/mutate_update.go
+++ b/pkg/cluster/mutate_update.go
@@ -5,70 +5,21 @@ import (
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type UpdateMutator struct {
-	ctrlCache  ctrl.Reader
-	ctrlClient ctrl.Client
-	logger     micrologger.Logger
-}
-
-type UpdateMutatorConfig struct {
-	CtrlCache  ctrl.Reader
-	CtrlClient ctrl.Client
-	Logger     micrologger.Logger
-}
-
-func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
-	if config.CtrlCache == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlCache must not be empty", config)
-	}
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	m := &UpdateMutator{
-		ctrlCache:  config.CtrlCache,
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return m, nil
-}
-
-func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnUpdateMutate(ctx context.Context, _ interface{}, object interface{}) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	clusterCR := &capi.Cluster{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, clusterCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse Cluster CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(clusterCR)
+	clusterCR, err := key.ToClusterPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
+	clusterCROriginal := clusterCR.DeepCopy()
 
-	patch, err := mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlCache, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err := mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, clusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -76,7 +27,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlCache, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, clusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -87,7 +38,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	clusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, clusterCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(clusterCROriginal, clusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -96,12 +47,4 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 
 	return result, nil
-}
-
-func (m *UpdateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *UpdateMutator) Resource() string {
-	return "cluster"
 }

--- a/pkg/cluster/validate_create.go
+++ b/pkg/cluster/validate_create.go
@@ -4,60 +4,15 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type CreateValidator struct {
-	baseDomain string
-	ctrlClient client.Client
-	logger     micrologger.Logger
-}
-
-type CreateValidatorConfig struct {
-	BaseDomain string
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-}
-
-func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
-	if config.BaseDomain == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
-	}
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	v := &CreateValidator{
-		baseDomain: config.BaseDomain,
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return v, nil
-}
-
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	clusterCR := &capi.Cluster{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, clusterCR); err != nil {
-		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(clusterCR)
+func (h *WebhookHandler) OnCreateValidate(ctx context.Context, object interface{}) error {
+	clusterCR, err := key.ToClusterPtr(object)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-	if capi {
-		return nil
 	}
 
 	err = clusterCR.ValidateCreate()
@@ -65,7 +20,7 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, clusterCR)
+	err = generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, h.ctrlClient, clusterCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -75,14 +30,10 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = validateControlPlaneEndpoint(*clusterCR, a.baseDomain)
+	err = validateControlPlaneEndpoint(*clusterCR, h.baseDomain)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	return nil
-}
-
-func (a *CreateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
 }

--- a/pkg/cluster/validate_update.go
+++ b/pkg/cluster/validate_update.go
@@ -22,6 +22,11 @@ func (h *WebhookHandler) OnUpdateValidate(ctx context.Context, oldObject interfa
 	if err != nil {
 		return microerror.Mask(err)
 	}
+	if !clusterNewCR.GetDeletionTimestamp().IsZero() {
+		h.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		return nil
+	}
+
 	clusterOldCR, err := key.ToClusterPtr(oldObject)
 	if err != nil {
 		return microerror.Mask(err)

--- a/pkg/cluster/validate_update.go
+++ b/pkg/cluster/validate_update.go
@@ -6,67 +6,25 @@ import (
 
 	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/conditions"
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/internal/releaseversion"
 	"github.com/giantswarm/azure-admission-controller/internal/semverhelper"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type UpdateValidator struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
-}
-
-type UpdateValidatorConfig struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-}
-
-func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	v := &UpdateValidator{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return v, nil
-}
-
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	clusterNewCR := &capi.Cluster{}
-	clusterOldCR := &capi.Cluster{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, clusterNewCR); err != nil {
-		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
-	}
-	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, clusterOldCR); err != nil {
-		return microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
-	}
-
-	if !clusterNewCR.GetDeletionTimestamp().IsZero() {
-		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
-		return nil
-	}
-
-	capi, err := generic.IsCAPIRelease(clusterNewCR)
+func (h *WebhookHandler) OnUpdateValidate(ctx context.Context, oldObject interface{}, object interface{}) error {
+	clusterNewCR, err := key.ToClusterPtr(object)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	if capi {
-		return nil
+	clusterOldCR, err := key.ToClusterPtr(oldObject)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	err = clusterNewCR.ValidateUpdate(clusterOldCR)
@@ -94,11 +52,7 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	return a.validateRelease(ctx, clusterOldCR, clusterNewCR)
-}
-
-func (a *UpdateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
+	return h.validateRelease(ctx, clusterOldCR, clusterNewCR)
 }
 
 func validateClusterNetworkUnchanged(old capi.Cluster, new capi.Cluster) error {
@@ -138,7 +92,7 @@ func validateClusterNetworkUnchanged(old capi.Cluster, new capi.Cluster) error {
 	return nil
 }
 
-func (a *UpdateValidator) validateRelease(ctx context.Context, clusterOldCR *capi.Cluster, clusterNewCR *capi.Cluster) error {
+func (h *WebhookHandler) validateRelease(ctx context.Context, clusterOldCR *capi.Cluster, clusterNewCR *capi.Cluster) error {
 	oldClusterVersion, err := semverhelper.GetSemverFromLabels(clusterOldCR.Labels)
 	if err != nil {
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from the Cluster being updated")
@@ -157,5 +111,5 @@ func (a *UpdateValidator) validateRelease(ctx context.Context, clusterOldCR *cap
 		}
 	}
 
-	return releaseversion.Validate(ctx, a.ctrlClient, oldClusterVersion, newClusterVersion)
+	return releaseversion.Validate(ctx, h.ctrlClient, oldClusterVersion, newClusterVersion)
 }

--- a/pkg/cluster/webhook_handler.go
+++ b/pkg/cluster/webhook_handler.go
@@ -1,0 +1,73 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+)
+
+type WebhookHandler struct {
+	baseDomain string
+	decoder    runtime.Decoder
+	ctrlCache  client.Reader
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+type WebhookHandlerConfig struct {
+	BaseDomain string
+	Decoder    runtime.Decoder
+	CtrlCache  client.Reader
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
+	if config.BaseDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
+	}
+	if config.Decoder == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Decoder must not be empty", config)
+	}
+	if config.CtrlCache == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlCache must not be empty", config)
+	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	v := &WebhookHandler{
+		baseDomain: config.BaseDomain,
+		decoder:    config.Decoder,
+		ctrlCache:  config.CtrlCache,
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return v, nil
+}
+
+func (h *WebhookHandler) Log(keyVals ...interface{}) {
+	h.logger.Log(keyVals...)
+}
+
+func (h *WebhookHandler) Resource() string {
+	return "cluster"
+}
+
+func (h *WebhookHandler) Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error) {
+	cr := &capi.Cluster{}
+	if _, _, err := h.decoder.Decode(rawObject.Raw, nil, cr); err != nil {
+		return nil, microerror.Maskf(errors.ParsingFailedError, "unable to parse Cluster CR: %v", err)
+	}
+
+	return cr, nil
+}

--- a/pkg/cluster/webhook_handler.go
+++ b/pkg/cluster/webhook_handler.go
@@ -14,7 +14,7 @@ import (
 type WebhookHandler struct {
 	baseDomain string
 	decoder    runtime.Decoder
-	ctrlCache  client.Reader
+	ctrlReader client.Reader
 	ctrlClient client.Client
 	logger     micrologger.Logger
 }
@@ -22,7 +22,7 @@ type WebhookHandler struct {
 type WebhookHandlerConfig struct {
 	BaseDomain string
 	Decoder    runtime.Decoder
-	CtrlCache  client.Reader
+	CtrlReader client.Reader
 	CtrlClient client.Client
 	Logger     micrologger.Logger
 }
@@ -34,8 +34,8 @@ func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
 	if config.Decoder == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Decoder must not be empty", config)
 	}
-	if config.CtrlCache == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlCache must not be empty", config)
+	if config.CtrlReader == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlReader must not be empty", config)
 	}
 	if config.CtrlClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
@@ -47,7 +47,7 @@ func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
 	v := &WebhookHandler{
 		baseDomain: config.BaseDomain,
 		decoder:    config.Decoder,
-		ctrlCache:  config.CtrlCache,
+		ctrlReader: config.CtrlReader,
 		ctrlClient: config.CtrlClient,
 		logger:     config.Logger,
 	}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -2,6 +2,11 @@ package key
 
 import (
 	"fmt"
+
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )
 
 const (
@@ -39,4 +44,17 @@ func OSDiskCachingType() string {
 
 func MasterSubnetName(clusterName string) string {
 	return fmt.Sprintf("%s-%s-%s", clusterName, "VirtualNetwork", "MasterSubnet")
+}
+
+func ToClusterPtr(v interface{}) (*capi.Cluster, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capi.Cluster{}, v)
+	}
+
+	customObjectPointer, ok := v.(*capi.Cluster)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capi.Cluster{}, v)
+	}
+
+	return customObjectPointer, nil
 }

--- a/pkg/unittest/decoder.go
+++ b/pkg/unittest/decoder.go
@@ -1,0 +1,16 @@
+package unittest
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type FakeDecoder struct{}
+
+func NewFakeDecoder() *FakeDecoder {
+	return &FakeDecoder{}
+}
+
+func (d *FakeDecoder) Decode(data []byte, defaults *schema.GroupVersionKind, into runtime.Object) (runtime.Object, *schema.GroupVersionKind, error) {
+	return nil, nil, nil
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `Cluster` CRD:
- `mutator.WebhookCreateHandler`
- `mutator.WebhookUpdateHandler`
- `validator.WebhookCreateHandler`
- `validator.WebhookUpdateHandler`

The implementation of these interfaces will replace current `CreateMutator`, `UpdateMutator`, `CreateValidator` and `UpdateValidator`. The important part here is that the mutation and validation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `Cluster` to use new `WebhookHandler` implementations
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementations
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster _(this PR)_
- AzureCluster https://github.com/giantswarm/azure-admission-controller/pull/273
- MachinePool https://github.com/giantswarm/azure-admission-controller/pull/274
- AzureMachinePool https://github.com/giantswarm/azure-admission-controller/pull/275
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark https://github.com/giantswarm/azure-admission-controller/pull/279
- AzureClusterConfig https://github.com/giantswarm/azure-admission-controller/pull/280
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281