### PR TITLE
Add azurecluster.WebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unit tests for functions from `release` package.
 - `HttpHandlerFactory` for creating HTTP handlers that are using new webhook handlers.
 - Cluster webhook handler that replaces mutators and validators.
+- AzureCluster webhook handler that replaces mutators and validators.
 
 ### Changed
 

--- a/pkg/azurecluster/mutate_update.go
+++ b/pkg/azurecluster/mutate_update.go
@@ -5,68 +5,19 @@ import (
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type UpdateMutator struct {
-	ctrlCache  ctrl.Reader
-	ctrlClient ctrl.Client
-	logger     micrologger.Logger
-}
-
-type UpdateMutatorConfig struct {
-	CtrlCache  ctrl.Reader
-	CtrlClient ctrl.Client
-	Logger     micrologger.Logger
-}
-
-func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
-	if config.CtrlCache == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlCache must not be empty", config)
-	}
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	m := &UpdateMutator{
-		ctrlCache:  config.CtrlCache,
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return m, nil
-}
-
-func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnUpdateMutate(ctx context.Context, _ interface{}, object interface{}) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	azureClusterCR := &capz.AzureCluster{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureClusterCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse AzureCluster CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(azureClusterCR)
+	azureClusterCR, err := key.ToAzureClusterPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
+	azureClusterCROriginal := azureClusterCR.DeepCopy()
 
 	patch, err := ensureAPIServerLB(azureClusterCR)
 	if err != nil {
@@ -76,7 +27,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlCache, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, azureClusterCR.GetObjectMeta(), "azure-operator", label.AzureOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -84,7 +35,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, m.ctrlCache, azureClusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
+	patch, err = mutator.EnsureComponentVersionLabelFromRelease(ctx, h.ctrlCache, azureClusterCR.GetObjectMeta(), "cluster-operator", label.ClusterOperatorVersion)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -95,7 +46,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureClusterCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureClusterCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(azureClusterCROriginal, azureClusterCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -107,12 +58,4 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 
 	return result, nil
-}
-
-func (m *UpdateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *UpdateMutator) Resource() string {
-	return "azurecluster"
 }

--- a/pkg/azurecluster/validate_create.go
+++ b/pkg/azurecluster/validate_create.go
@@ -4,66 +4,16 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type CreateValidator struct {
-	baseDomain string
-	ctrlClient client.Client
-	location   string
-	logger     micrologger.Logger
-}
-
-type CreateValidatorConfig struct {
-	BaseDomain string
-	CtrlClient client.Client
-	Location   string
-	Logger     micrologger.Logger
-}
-
-func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
-	if config.BaseDomain == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
-	}
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.Location == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
-	}
-
-	v := &CreateValidator{
-		baseDomain: config.BaseDomain,
-		ctrlClient: config.CtrlClient,
-		location:   config.Location,
-		logger:     config.Logger,
-	}
-
-	return v, nil
-}
-
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	azureClusterCR := &capz.AzureCluster{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureClusterCR); err != nil {
-		return microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(azureClusterCR)
+func (h *WebhookHandler) OnCreateValidate(ctx context.Context, object interface{}) error {
+	azureClusterCR, err := key.ToAzureClusterPtr(object)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-	if capi {
-		return nil
 	}
 
 	err = azureClusterCR.ValidateCreate()
@@ -74,24 +24,20 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, a.ctrlClient, azureClusterCR)
+	err = generic.ValidateOrganizationLabelContainsExistingOrganization(ctx, h.ctrlClient, azureClusterCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = validateControlPlaneEndpoint(*azureClusterCR, a.baseDomain)
+	err = validateControlPlaneEndpoint(*azureClusterCR, h.baseDomain)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = validateLocation(*azureClusterCR, a.location)
+	err = validateLocation(*azureClusterCR, h.location)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	return nil
-}
-
-func (a *CreateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
 }

--- a/pkg/azurecluster/validate_create_test.go
+++ b/pkg/azurecluster/validate_create_test.go
@@ -7,9 +7,8 @@ import (
 	securityv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/security/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/azurecluster"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
@@ -18,34 +17,34 @@ import (
 func TestAzureClusterCreateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
-		azureCluster []byte
+		azureCluster *capz.AzureCluster
 		errorMatcher func(err error) bool
 	}
 
 	testCases := []testCase{
 		{
 			name:         "case 0: empty ControlPlaneEndpoint",
-			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("", 443)),
+			azureCluster: builder.BuildAzureCluster(builder.Name("ab123"), builder.ControlPlaneEndpoint("", 443)),
 			errorMatcher: IsInvalidControlPlaneEndpointHostError,
 		},
 		{
 			name:         "case 1: Invalid Port",
-			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
+			azureCluster: builder.BuildAzureCluster(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 80)),
 			errorMatcher: IsInvalidControlPlaneEndpointPortError,
 		},
 		{
 			name:         "case 2: Invalid Host",
-			azureCluster: builder.BuildAzureClusterAsJson(builder.ControlPlaneEndpoint("api.gigantic.io", 443), builder.Location("westeurope")),
+			azureCluster: builder.BuildAzureCluster(builder.ControlPlaneEndpoint("api.gigantic.io", 443), builder.Location("westeurope")),
 			errorMatcher: IsInvalidControlPlaneEndpointHostError,
 		},
 		{
 			name:         "case 3: Valid values",
-			azureCluster: builder.BuildAzureClusterAsJson(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443), builder.Location("westeurope")),
+			azureCluster: builder.BuildAzureCluster(builder.Name("ab123"), builder.ControlPlaneEndpoint("api.ab123.k8s.test.westeurope.azure.gigantic.io", 443), builder.Location("westeurope")),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Invalid region",
-			azureCluster: builder.BuildAzureClusterAsJson(builder.Location("westpoland")),
+			azureCluster: builder.BuildAzureCluster(builder.Location("westpoland")),
 			errorMatcher: IsUnexpectedLocationError,
 		},
 	}
@@ -79,15 +78,20 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit := &CreateValidator{
-				baseDomain: "k8s.test.westeurope.azure.gigantic.io",
-				ctrlClient: ctrlClient,
-				location:   "westeurope",
-				logger:     newLogger,
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				BaseDomain: "k8s.test.westeurope.azure.gigantic.io",
+				CtrlCache:  ctrlClient,
+				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
+				Location:   "westeurope",
+				Logger:     newLogger,
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.azureCluster))
+			// Run validating webhook handler on AzureCluster creation.
+			err = handler.OnCreateValidate(ctx, tc.azureCluster)
 
 			// Check if the error is the expected one.
 			switch {
@@ -102,20 +106,4 @@ func TestAzureClusterCreateValidate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getCreateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azurecluster",
-		},
-		Operation: v1beta1.Create,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/azurecluster/webhook_handler.go
+++ b/pkg/azurecluster/webhook_handler.go
@@ -1,0 +1,80 @@
+package azurecluster
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+)
+
+type WebhookHandler struct {
+	baseDomain string
+	ctrlCache  client.Reader
+	ctrlClient client.Client
+	decoder    runtime.Decoder
+	location   string
+	logger     micrologger.Logger
+}
+
+type WebhookHandlerConfig struct {
+	BaseDomain string
+	CtrlCache  client.Reader
+	CtrlClient client.Client
+	Decoder    runtime.Decoder
+	Location   string
+	Logger     micrologger.Logger
+}
+
+func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
+	if config.BaseDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
+	}
+	if config.CtrlCache == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlCache must not be empty", config)
+	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Decoder == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Decoder must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Location == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
+	}
+
+	v := &WebhookHandler{
+		baseDomain: config.BaseDomain,
+		ctrlCache:  config.CtrlCache,
+		ctrlClient: config.CtrlClient,
+		decoder:    config.Decoder,
+		location:   config.Location,
+		logger:     config.Logger,
+	}
+
+	return v, nil
+}
+
+func (h *WebhookHandler) Log(keyVals ...interface{}) {
+	h.logger.Log(keyVals...)
+}
+
+func (h *WebhookHandler) Resource() string {
+	return "azurecluster"
+}
+
+func (h *WebhookHandler) Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error) {
+	azureClusterCR := &capz.AzureCluster{}
+	if _, _, err := validator.Deserializer.Decode(rawObject.Raw, nil, azureClusterCR); err != nil {
+		return nil, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureCluster CR: %v", err)
+	}
+
+	return azureClusterCR, nil
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
@@ -54,6 +55,19 @@ func ToClusterPtr(v interface{}) (*capi.Cluster, error) {
 	customObjectPointer, ok := v.(*capi.Cluster)
 	if !ok {
 		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capi.Cluster{}, v)
+	}
+
+	return customObjectPointer, nil
+}
+
+func ToAzureClusterPtr(v interface{}) (*capz.AzureCluster, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capz.AzureCluster{}, v)
+	}
+
+	customObjectPointer, ok := v.(*capz.AzureCluster)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capz.AzureCluster{}, v)
 	}
 
 	return customObjectPointer, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `AzureCluster` CRD:
- `mutator.WebhookCreateHandler`
- `mutator.WebhookUpdateHandler`
- `validator.WebhookCreateHandler`
- `validator.WebhookUpdateHandler`

The implementation of these interfaces will replace current `CreateMutator`, `UpdateMutator`, `CreateValidator` and `UpdateValidator`. The important part here is that the mutation and validation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `AzureCluster` to use new `WebhookHandler` implementations
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementations
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster https://github.com/giantswarm/azure-admission-controller/pull/272
- AzureCluster _(this PR)_
- MachinePool https://github.com/giantswarm/azure-admission-controller/pull/274
- AzureMachinePool https://github.com/giantswarm/azure-admission-controller/pull/275
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark https://github.com/giantswarm/azure-admission-controller/pull/279
- AzureClusterConfig https://github.com/giantswarm/azure-admission-controller/pull/280
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281