### PR TITLE
Add machinepool.WebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `HttpHandlerFactory` for creating HTTP handlers that are using new webhook handlers.
 - Cluster webhook handler that replaces mutators and validators.
 - AzureCluster webhook handler that replaces mutators and validators.
+- MachinePool webhook handler that replaces mutators and validators.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -325,6 +325,7 @@ func mainError() error {
 	{
 		c := machinepool.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
+			Decoder:    universalDeserializer,
 			Logger:     newLogger,
 			VMcaps:     vmcaps,
 		}

--- a/main.go
+++ b/main.go
@@ -321,48 +321,14 @@ func mainError() error {
 		}
 	}
 
-	var machinePoolCreateMutator *machinepool.CreateMutator
+	var machinePoolWebhookHandler *machinepool.WebhookHandler
 	{
-		c := machinepool.CreateMutatorConfig{
-			CtrlClient: ctrlClient,
-			Logger:     newLogger,
-		}
-		machinePoolCreateMutator, err = machinepool.NewCreateMutator(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var machinePoolUpdateMutator *machinepool.UpdateMutator
-	{
-		c := machinepool.UpdateMutatorConfig{
-			Logger: newLogger,
-		}
-		machinePoolUpdateMutator, err = machinepool.NewUpdateMutator(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var machinePoolCreateValidator *machinepool.CreateValidator
-	{
-		c := machinepool.CreateValidatorConfig{
+		c := machinepool.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
 			Logger:     newLogger,
 			VMcaps:     vmcaps,
 		}
-		machinePoolCreateValidator, err = machinepool.NewCreateValidator(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var machinePoolUpdateValidator *machinepool.UpdateValidator
-	{
-		c := machinepool.UpdateValidatorConfig{
-			Logger: newLogger,
-		}
-		machinePoolUpdateValidator, err = machinepool.NewUpdateValidator(c)
+		machinePoolWebhookHandler, err = machinepool.NewWebhookHandler(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -415,8 +381,8 @@ func mainError() error {
 	handler.Handle("/mutate/azurecluster/update", mutatorHttpHandlerFactory.NewUpdateHandler(azureClusterWebhookHandler))
 	handler.Handle("/mutate/cluster/create", mutatorHttpHandlerFactory.NewCreateHandler(clusterWebhookHandler))
 	handler.Handle("/mutate/cluster/update", mutatorHttpHandlerFactory.NewUpdateHandler(clusterWebhookHandler))
-	handler.Handle("/mutate/machinepool/create", mutator.Handler(machinePoolCreateMutator))
-	handler.Handle("/mutate/machinepool/update", mutator.Handler(machinePoolUpdateMutator))
+	handler.Handle("/mutate/machinepool/create", mutatorHttpHandlerFactory.NewCreateHandler(machinePoolWebhookHandler))
+	handler.Handle("/mutate/machinepool/update", mutatorHttpHandlerFactory.NewUpdateHandler(machinePoolWebhookHandler))
 	handler.Handle("/mutate/spark/create", mutator.Handler(sparkCreateMutator))
 
 	// Validators.
@@ -430,8 +396,8 @@ func mainError() error {
 	handler.Handle("/validate/azuremachinepool/update", validator.Handler(azureMachinePoolUpdateValidator))
 	handler.Handle("/validate/cluster/create", validatorHttpHandlerFactory.NewCreateHandler(clusterWebhookHandler))
 	handler.Handle("/validate/cluster/update", validatorHttpHandlerFactory.NewUpdateHandler(clusterWebhookHandler))
-	handler.Handle("/validate/machinepool/create", validator.Handler(machinePoolCreateValidator))
-	handler.Handle("/validate/machinepool/update", validator.Handler(machinePoolUpdateValidator))
+	handler.Handle("/validate/machinepool/create", validatorHttpHandlerFactory.NewCreateHandler(machinePoolWebhookHandler))
+	handler.Handle("/validate/machinepool/update", validatorHttpHandlerFactory.NewUpdateHandler(machinePoolWebhookHandler))
 	handler.HandleFunc("/healthz", healthCheck)
 
 	newLogger.LogCtx(context.Background(), "level", "debug", "message", fmt.Sprintf("Listening on port %s", cfg.Address))

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )
@@ -68,6 +69,19 @@ func ToAzureClusterPtr(v interface{}) (*capz.AzureCluster, error) {
 	customObjectPointer, ok := v.(*capz.AzureCluster)
 	if !ok {
 		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capz.AzureCluster{}, v)
+	}
+
+	return customObjectPointer, nil
+}
+
+func ToMachinePoolPtr(v interface{}) (*capiexp.MachinePool, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capiexp.MachinePool{}, v)
+	}
+
+	customObjectPointer, ok := v.(*capiexp.MachinePool)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capiexp.MachinePool{}, v)
 	}
 
 	return customObjectPointer, nil

--- a/pkg/machinepool/defaults.go
+++ b/pkg/machinepool/defaults.go
@@ -1,17 +1,3 @@
 package machinepool
 
-import (
-	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-
-	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
-)
-
 const defaultReplicas int64 = 1
-
-// setDefaultSpecValues checks if some optional field is not set, and sets
-// default values defined by upstream Cluster API.
-func setDefaultSpecValues(m mutator.Mutator, machinePool *capiexp.MachinePool) []mutator.PatchOperation {
-	var patches []mutator.PatchOperation
-
-	return patches
-}

--- a/pkg/machinepool/mutate_create_test.go
+++ b/pkg/machinepool/mutate_create_test.go
@@ -219,6 +219,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Logger:     newLogger,
 				VMcaps:     vmcaps,
 			})

--- a/pkg/machinepool/mutate_create_test.go
+++ b/pkg/machinepool/mutate_create_test.go
@@ -227,7 +227,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 			}
 
 			// Run mutating webhook handler on MachinePool creation.
-			patches, err := handler.OnCreateMutate(context.Background(), tc.nodePool)
+			patches, err := handler.OnCreateMutate(ctx, tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {

--- a/pkg/machinepool/mutate_create_test.go
+++ b/pkg/machinepool/mutate_create_test.go
@@ -5,16 +5,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
@@ -22,7 +23,7 @@ import (
 func TestMachinePoolCreateMutate(t *testing.T) {
 	type testCase struct {
 		name         string
-		nodePool     []byte
+		nodePool     *capiexp.MachinePool
 		patches      []mutator.PatchOperation
 		errorMatcher func(err error) bool
 	}
@@ -30,7 +31,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     "case 0: set default number of replicas",
-			nodePool: builder.BuildMachinePoolAsJson(),
+			nodePool: builder.BuildMachinePool(),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "replace",
@@ -52,7 +53,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 1: set min replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -74,7 +75,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 2: set max replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -96,7 +97,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 3: set min and max replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -123,7 +124,7 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 4: set min and max replicas annotation when replicas field is not set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -206,16 +207,27 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit, err := NewCreateMutator(CreateMutatorConfig{
-				CtrlClient: ctrlClient,
-				Logger:     newLogger,
+			stubbedSKUs := map[string]compute.ResourceSku{}
+			stubAPI := NewStubAPI(stubbedSKUs)
+			vmcaps, err := vmcapabilities.New(vmcapabilities.Config{
+				Azure:  stubAPI,
+				Logger: newLogger,
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			patches, err := admit.Mutate(context.Background(), getCreateMutateAdmissionRequest(tc.nodePool))
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Run mutating webhook handler on MachinePool creation.
+			patches, err := handler.OnCreateMutate(context.Background(), tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -235,20 +247,4 @@ func TestMachinePoolCreateMutate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getCreateMutateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "machinepool",
-		},
-		Operation: v1beta1.Create,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/machinepool/mutate_update.go
+++ b/pkg/machinepool/mutate_update.go
@@ -4,66 +4,23 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type UpdateMutator struct {
-	logger micrologger.Logger
-}
-
-type UpdateMutatorConfig struct {
-	Logger micrologger.Logger
-}
-
-func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	m := &UpdateMutator{
-		logger: config.Logger,
-	}
-
-	return m, nil
-}
-
-func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnUpdateMutate(_ context.Context, _ interface{}, object interface{}) ([]mutator.PatchOperation, error) {
 	var err error
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	machinePoolCR := &capiexp.MachinePool{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, machinePoolCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse MachinePool CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(machinePoolCR)
+	machinePoolCR, err := key.ToMachinePoolPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
-
-	// Values for some optional spec fields could be removed in a CR update, so
-	// here we set them back again to their default values.
-	defaultSpecValues := setDefaultSpecValues(m, machinePoolCR)
-	if defaultSpecValues != nil {
-		result = append(result, defaultSpecValues...)
-	}
+	machinePoolCROriginal := machinePoolCR.DeepCopy()
 
 	// Ensure autoscaling annotations are set.
-	patch := ensureAutoscalingAnnotations(m, machinePoolCR)
+	patch := ensureAutoscalingAnnotations(h, machinePoolCR)
 	if patch != nil {
 		result = append(result, patch...)
 	}
@@ -71,7 +28,7 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	machinePoolCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, machinePoolCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(machinePoolCROriginal, machinePoolCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -80,12 +37,4 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 
 	return result, nil
-}
-
-func (m *UpdateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *UpdateMutator) Resource() string {
-	return "machinepool"
 }

--- a/pkg/machinepool/mutate_update_test.go
+++ b/pkg/machinepool/mutate_update_test.go
@@ -281,7 +281,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			}
 
 			// Run mutating webhook handler on MachinePool update.
-			patches, err := handler.OnUpdateMutate(context.Background(), nil, tc.nodePool)
+			patches, err := handler.OnUpdateMutate(ctx, nil, tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {

--- a/pkg/machinepool/mutate_update_test.go
+++ b/pkg/machinepool/mutate_update_test.go
@@ -273,6 +273,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Logger:     newLogger,
 				VMcaps:     vmcaps,
 			})

--- a/pkg/machinepool/mutate_update_test.go
+++ b/pkg/machinepool/mutate_update_test.go
@@ -5,16 +5,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
@@ -22,7 +23,7 @@ import (
 func TestMachinePoolUpdateMutate(t *testing.T) {
 	type testCase struct {
 		name         string
-		nodePool     []byte
+		nodePool     *capiexp.MachinePool
 		patches      []mutator.PatchOperation
 		errorMatcher func(err error) bool
 	}
@@ -30,7 +31,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     "case 0: set default number of replicas",
-			nodePool: builder.BuildMachinePoolAsJson(),
+			nodePool: builder.BuildMachinePool(),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "replace",
@@ -52,7 +53,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 1: set min replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -74,7 +75,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 2: set max replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -96,7 +97,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 3: set min and max replicas annotation when replicas field is set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Replicas(7), builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -123,7 +124,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 4: set min and max replicas annotation when replicas field is not set",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
+			nodePool: builder.BuildMachinePool(builder.Annotation(annotation.NodePoolMinSize, ""), builder.Annotation(annotation.NodePoolMaxSize, "")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -155,7 +156,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 5: set max replicas annotation when invalid",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMaxSize, "INVALID")),
+			nodePool: builder.BuildMachinePool(builder.Annotation(annotation.NodePoolMaxSize, "INVALID")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "replace",
@@ -182,7 +183,7 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 6: set min replicas annotation when invalid",
-			nodePool: builder.BuildMachinePoolAsJson(builder.Annotation(annotation.NodePoolMinSize, "INVALID")),
+			nodePool: builder.BuildMachinePool(builder.Annotation(annotation.NodePoolMinSize, "INVALID")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "replace",
@@ -260,15 +261,27 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit, err := NewUpdateMutator(UpdateMutatorConfig{
+			stubbedSKUs := map[string]compute.ResourceSku{}
+			stubAPI := NewStubAPI(stubbedSKUs)
+			vmcaps, err := vmcapabilities.New(vmcapabilities.Config{
+				Azure:  stubAPI,
 				Logger: newLogger,
+			})
+			if err != nil {
+				t.Fatal(microerror.JSON(err))
+			}
+
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			patches, err := admit.Mutate(context.Background(), getUpdateMutateAdmissionRequest(tc.nodePool))
+			// Run mutating webhook handler on MachinePool update.
+			patches, err := handler.OnUpdateMutate(context.Background(), nil, tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -288,20 +301,4 @@ func TestMachinePoolUpdateMutate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getUpdateMutateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "machinepool",
-		},
-		Operation: v1beta1.Update,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/machinepool/validate_create.go
+++ b/pkg/machinepool/validate_create.go
@@ -4,61 +4,18 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type CreateValidator struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
-	vmcaps     *vmcapabilities.VMSKU
-}
-
-type CreateValidatorConfig struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-	VMcaps     *vmcapabilities.VMSKU
-}
-
-func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.VMcaps == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
-	}
-
-	admitter := &CreateValidator{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-		vmcaps:     config.VMcaps,
-	}
-
-	return admitter, nil
-}
-
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	machinePoolNewCR := &capiexp.MachinePool{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, machinePoolNewCR); err != nil {
-		return microerror.Maskf(parsingFailedError, "unable to parse machinePool CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(machinePoolNewCR)
+func (h *WebhookHandler) OnCreateValidate(ctx context.Context, object interface{}) error {
+	machinePoolNewCR, err := key.ToMachinePoolPtr(object)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-	if capi {
-		return nil
 	}
 
 	err = machinePoolNewCR.ValidateCreate()
@@ -66,12 +23,12 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = generic.ValidateOrganizationLabelMatchesCluster(ctx, a.ctrlClient, machinePoolNewCR)
+	err = generic.ValidateOrganizationLabelMatchesCluster(ctx, h.ctrlClient, machinePoolNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = a.checkAvailabilityZones(ctx, machinePoolNewCR)
+	err = h.checkAvailabilityZones(ctx, machinePoolNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -79,22 +36,18 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	return nil
 }
 
-func (a *CreateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
-}
-
-func (a *CreateValidator) checkAvailabilityZones(ctx context.Context, mp *capiexp.MachinePool) error {
+func (h *WebhookHandler) checkAvailabilityZones(ctx context.Context, mp *capiexp.MachinePool) error {
 	// Get the AzureMachinePool CR related to this MachinePool (we need it to get the VM type).
 	if mp.Spec.Template.Spec.InfrastructureRef.Namespace == "" || mp.Spec.Template.Spec.InfrastructureRef.Name == "" {
 		return microerror.Maskf(azureMachinePoolNotFoundError, "MachinePool's InfrastructureRef has to be set")
 	}
 	amp := capzexp.AzureMachinePool{}
-	err := a.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
+	err := h.ctrlClient.Get(ctx, client.ObjectKey{Namespace: mp.Spec.Template.Spec.InfrastructureRef.Namespace, Name: mp.Spec.Template.Spec.InfrastructureRef.Name}, &amp)
 	if err != nil {
 		return microerror.Maskf(azureMachinePoolNotFoundError, "AzureMachinePool has to be created before the related MachinePool")
 	}
 
-	supportedZones, err := a.vmcaps.SupportedAZs(ctx, amp.Spec.Location, amp.Spec.Template.VMSize)
+	supportedZones, err := h.vmcaps.SupportedAZs(ctx, amp.Spec.Location, amp.Spec.Template.VMSize)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/machinepool/validate_create_test.go
+++ b/pkg/machinepool/validate_create_test.go
@@ -224,6 +224,7 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Logger:     newLogger,
 				VMcaps:     vmcaps,
 			})

--- a/pkg/machinepool/validate_create_test.go
+++ b/pkg/machinepool/validate_create_test.go
@@ -10,11 +10,10 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
@@ -30,7 +29,7 @@ const (
 func TestMachinePoolCreateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
-		machinePool  []byte
+		machinePool  *capiexp.MachinePool
 		vmType       string
 		errorMatcher func(err error) bool
 	}
@@ -38,43 +37,43 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:         "case 0: instance type supporting [1,2,3], requested [1]",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"1"})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"1"})),
 			vmType:       "Standard_A2_v2",
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: instance type supporting [1,2], requested [3]",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"3"})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"3"})),
 			vmType:       "Standard_A4_v2",
 			errorMatcher: IsUnsupportedFailureDomainError,
 		},
 		{
 			name:         "case 2: instance type supporting [1,2], requested [2,3]",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"2,3"})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"2,3"})),
 			vmType:       "Standard_A4_v2",
 			errorMatcher: IsUnsupportedFailureDomainError,
 		},
 		{
 			name:         "case 3: instance type supporting [], requested [1]",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"1"})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{"1"})),
 			vmType:       "Standard_A8_v2",
 			errorMatcher: IsUnsupportedFailureDomainError,
 		},
 		{
 			name:         "case 4: instance type supporting [], requested []",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{})),
 			vmType:       "Standard_A8_v2",
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 5: AzureMachinePool does not exist",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{})),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.FailureDomains([]string{})),
 			vmType:       "",
 			errorMatcher: IsAzureMachinePoolNotFound,
 		},
 		{
 			name:         "case 6: Wrong Organization",
-			machinePool:  builder.BuildMachinePoolAsJson(builder.AzureMachinePool(machinePoolName), builder.Organization("wrongorg")),
+			machinePool:  builder.BuildMachinePool(builder.AzureMachinePool(machinePoolName), builder.Organization("wrongorg")),
 			vmType:       "",
 			errorMatcher: generic.IsNodepoolOrgDoesNotMatchClusterOrg,
 		},
@@ -223,7 +222,7 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit, err := NewCreateValidator(CreateValidatorConfig{
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
 				Logger:     newLogger,
 				VMcaps:     vmcaps,
@@ -232,8 +231,8 @@ func TestMachinePoolCreateValidate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.machinePool))
+			// Run validating webhook handler on MachinePool creation.
+			err = handler.OnCreateValidate(ctx, tc.machinePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -258,22 +257,6 @@ func NewStubAPI(stubbedSKUs map[string]compute.ResourceSku) vmcapabilities.API {
 	return &StubAPI{stubbedSKUs: stubbedSKUs}
 }
 
-func (s *StubAPI) List(ctx context.Context, filter string) (map[string]compute.ResourceSku, error) {
+func (s *StubAPI) List(_ context.Context, _ string) (map[string]compute.ResourceSku, error) {
 	return s.stubbedSKUs, nil
-}
-
-func getCreateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azuremachinepool",
-		},
-		Operation: v1beta1.Create,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/machinepool/validate_update_test.go
+++ b/pkg/machinepool/validate_update_test.go
@@ -56,6 +56,7 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 				}
 			}
 
+			ctx := context.Background()
 			fakeK8sClient := unittest.FakeK8sClient()
 			ctrlClient := fakeK8sClient.CtrlClient()
 
@@ -79,7 +80,7 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 			}
 
 			// Run validating webhook handler on MachinePool update.
-			err = handler.OnUpdateValidate(context.Background(), tc.oldNodePool, tc.newNodePool)
+			err = handler.OnUpdateValidate(ctx, tc.oldNodePool, tc.newNodePool)
 
 			// Check if the error is the expected one.
 			switch {

--- a/pkg/machinepool/validate_update_test.go
+++ b/pkg/machinepool/validate_update_test.go
@@ -4,40 +4,41 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/machinepool"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
 func TestMachinePoolUpdateValidate(t *testing.T) {
 	type testCase struct {
 		name         string
-		oldNodePool  []byte
-		newNodePool  []byte
+		oldNodePool  *capiexp.MachinePool
+		newNodePool  *capiexp.MachinePool
 		errorMatcher func(err error) bool
 	}
 
 	testCases := []testCase{
 		{
 			name:         "case 0: FailureDomains unchanged",
-			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1", "2"})),
-			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1", "2"})),
+			oldNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"1", "2"})),
+			newNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"1", "2"})),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: FailureDomains changed",
-			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1"})),
-			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"2"})),
+			oldNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"1"})),
+			newNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"2"})),
 			errorMatcher: IsFailureDomainWasChangedError,
 		},
 		{
 			name:         "case 2: FailureDomains changed but object is being deleted",
-			oldNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"1"})),
-			newNodePool:  builder.BuildMachinePoolAsJson(builder.FailureDomains([]string{"2"}), builder.WithDeletionTimestamp()),
+			oldNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"1"})),
+			newNodePool:  builder.BuildMachinePool(builder.FailureDomains([]string{"2"}), builder.WithDeletionTimestamp()),
 			errorMatcher: nil,
 		},
 	}
@@ -55,15 +56,30 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 				}
 			}
 
-			admit, err := NewUpdateValidator(UpdateValidatorConfig{
+			fakeK8sClient := unittest.FakeK8sClient()
+			ctrlClient := fakeK8sClient.CtrlClient()
+
+			stubbedSKUs := map[string]compute.ResourceSku{}
+			stubAPI := NewStubAPI(stubbedSKUs)
+			vmcaps, err := vmcapabilities.New(vmcapabilities.Config{
+				Azure:  stubAPI,
 				Logger: newLogger,
+			})
+			if err != nil {
+				t.Fatal(microerror.JSON(err))
+			}
+
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
 			})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			err = admit.Validate(context.Background(), getUpdateAdmissionRequest(tc.oldNodePool, tc.newNodePool))
+			// Run validating webhook handler on MachinePool update.
+			err = handler.OnUpdateValidate(context.Background(), tc.oldNodePool, tc.newNodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -78,24 +94,4 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getUpdateAdmissionRequest(oldMP []byte, newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azuremachinepool",
-		},
-		Operation: v1beta1.Update,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-		OldObject: runtime.RawExtension{
-			Raw:    oldMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/machinepool/validate_update_test.go
+++ b/pkg/machinepool/validate_update_test.go
@@ -72,6 +72,7 @@ func TestMachinePoolUpdateValidate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Logger:     newLogger,
 				VMcaps:     vmcaps,
 			})

--- a/pkg/machinepool/webhook_handler.go
+++ b/pkg/machinepool/webhook_handler.go
@@ -1,0 +1,63 @@
+package machinepool
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+)
+
+type WebhookHandler struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	vmcaps     *vmcapabilities.VMSKU
+}
+
+type WebhookHandlerConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	VMcaps     *vmcapabilities.VMSKU
+}
+
+func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.VMcaps == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
+	}
+
+	handler := &WebhookHandler{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		vmcaps:     config.VMcaps,
+	}
+
+	return handler, nil
+}
+
+func (h *WebhookHandler) Log(keyVals ...interface{}) {
+	h.logger.Log(keyVals...)
+}
+
+func (h *WebhookHandler) Resource() string {
+	return "machinepool"
+}
+
+func (h *WebhookHandler) Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error) {
+	cr := &capiexp.MachinePool{}
+	if _, _, err := validator.Deserializer.Decode(rawObject.Raw, nil, cr); err != nil {
+		return nil, microerror.Maskf(errors.ParsingFailedError, "unable to parse MachinePool CR: %v", err)
+	}
+
+	return cr, nil
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `MachinePool` CRD:
- `mutator.WebhookCreateHandler`
- `mutator.WebhookUpdateHandler`
- `validator.WebhookCreateHandler`
- `validator.WebhookUpdateHandler`

The implementation of these interfaces will replace current `CreateMutator`, `UpdateMutator`, `CreateValidator` and `UpdateValidator`. The important part here is that the mutation and validation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `MachinePool` to use new `WebhookHandler` implementations
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementations
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster https://github.com/giantswarm/azure-admission-controller/pull/272
- AzureCluster https://github.com/giantswarm/azure-admission-controller/pull/273
- MachinePool _(this PR)_
- AzureMachinePool https://github.com/giantswarm/azure-admission-controller/pull/275
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark https://github.com/giantswarm/azure-admission-controller/pull/279
- AzureClusterConfig https://github.com/giantswarm/azure-admission-controller/pull/280
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281