### PR TITLE
Add azuremachinepool.WebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cluster webhook handler that replaces mutators and validators.
 - AzureCluster webhook handler that replaces mutators and validators.
 - MachinePool webhook handler that replaces mutators and validators.
+- AzureMachinePool webhook handler that replaces mutators and validators.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -334,30 +334,6 @@ func mainError() error {
 		}
 	}
 
-	var validatorHttpHandlerFactory *validator.HttpHandlerFactory
-	{
-		c := validator.HttpHandlerFactoryConfig{
-			CtrlClient: ctrlClient,
-			CtrlCache:  ctrlCache,
-		}
-		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var mutatorHttpHandlerFactory *mutator.HttpHandlerFactory
-	{
-		c := mutator.HttpHandlerFactoryConfig{
-			CtrlClient: ctrlClient,
-			CtrlCache:  ctrlCache,
-		}
-		mutatorHttpHandlerFactory, err = mutator.NewHttpHandlerFactory(c)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
 	// Here we register our endpoints.
 	handler := http.NewServeMux()
 	// Mutators.

--- a/main.go
+++ b/main.go
@@ -371,6 +371,28 @@ func mainError() error {
 		}
 	}
 
+	var validatorHttpHandlerFactory *validator.HttpHandlerFactory
+	{
+		c := validator.HttpHandlerFactoryConfig{
+			CtrlClient: ctrlClient,
+		}
+		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var mutatorHttpHandlerFactory *mutator.HttpHandlerFactory
+	{
+		c := mutator.HttpHandlerFactoryConfig{
+			CtrlClient: ctrlClient,
+		}
+		mutatorHttpHandlerFactory, err = mutator.NewHttpHandlerFactory(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	// Here we register our endpoints.
 	handler := http.NewServeMux()
 	// Mutators.

--- a/main.go
+++ b/main.go
@@ -232,6 +232,7 @@ func mainError() error {
 	{
 		c := azuremachinepool.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
+			Decoder:    universalDeserializer,
 			Location:   cfg.Location,
 			Logger:     newLogger,
 			VMcaps:     vmcaps,

--- a/main.go
+++ b/main.go
@@ -228,53 +228,15 @@ func mainError() error {
 		}
 	}
 
-	var azureMachinePoolCreateMutator *azuremachinepool.CreateMutator
+	var azureMachinePoolWebhookHandler *azuremachinepool.WebhookHandler
 	{
-		createMutatorConfig := azuremachinepool.CreateMutatorConfig{
+		c := azuremachinepool.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
 			Location:   cfg.Location,
 			Logger:     newLogger,
 			VMcaps:     vmcaps,
 		}
-		azureMachinePoolCreateMutator, err = azuremachinepool.NewCreateMutator(createMutatorConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var azureMachinePoolUpdateMutator *azuremachinepool.UpdateMutator
-	{
-		updateMutatorConfig := azuremachinepool.UpdateMutatorConfig{
-			CtrlClient: ctrlClient,
-			Logger:     newLogger,
-		}
-		azureMachinePoolUpdateMutator, err = azuremachinepool.NewUpdateMutator(updateMutatorConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var azureMachinePoolCreateValidator *azuremachinepool.CreateValidator
-	{
-		createValidatorConfig := azuremachinepool.CreateValidatorConfig{
-			CtrlClient: ctrlClient,
-			Location:   cfg.Location,
-			Logger:     newLogger,
-			VMcaps:     vmcaps,
-		}
-		azureMachinePoolCreateValidator, err = azuremachinepool.NewCreateValidator(createValidatorConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var azureMachinePoolUpdateValidator *azuremachinepool.UpdateValidator
-	{
-		updateValidatorConfig := azuremachinepool.UpdateValidatorConfig{
-			Logger: newLogger,
-			VMcaps: vmcaps,
-		}
-		azureMachinePoolUpdateValidator, err = azuremachinepool.NewUpdateValidator(updateValidatorConfig)
+		azureMachinePoolWebhookHandler, err = azuremachinepool.NewWebhookHandler(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -400,8 +362,8 @@ func mainError() error {
 	// Mutators.
 	handler.Handle("/mutate/azuremachine/create", mutator.Handler(azureMachineCreateMutator))
 	handler.Handle("/mutate/azuremachine/update", mutator.Handler(azureMachineUpdateMutator))
-	handler.Handle("/mutate/azuremachinepool/create", mutator.Handler(azureMachinePoolCreateMutator))
-	handler.Handle("/mutate/azuremachinepool/update", mutator.Handler(azureMachinePoolUpdateMutator))
+	handler.Handle("/mutate/azuremachinepool/create", mutatorHttpHandlerFactory.NewCreateHandler(azureMachinePoolWebhookHandler))
+	handler.Handle("/mutate/azuremachinepool/update", mutatorHttpHandlerFactory.NewUpdateHandler(azureMachinePoolWebhookHandler))
 	handler.Handle("/mutate/azurecluster/create", mutatorHttpHandlerFactory.NewCreateHandler(azureClusterWebhookHandler))
 	handler.Handle("/mutate/azurecluster/update", mutatorHttpHandlerFactory.NewUpdateHandler(azureClusterWebhookHandler))
 	handler.Handle("/mutate/cluster/create", mutatorHttpHandlerFactory.NewCreateHandler(clusterWebhookHandler))
@@ -417,8 +379,8 @@ func mainError() error {
 	handler.Handle("/validate/azurecluster/update", validatorHttpHandlerFactory.NewUpdateHandler(azureClusterWebhookHandler))
 	handler.Handle("/validate/azuremachine/create", validator.Handler(azureMachineCreateValidator))
 	handler.Handle("/validate/azuremachine/update", validator.Handler(azureMachineUpdateValidator))
-	handler.Handle("/validate/azuremachinepool/create", validator.Handler(azureMachinePoolCreateValidator))
-	handler.Handle("/validate/azuremachinepool/update", validator.Handler(azureMachinePoolUpdateValidator))
+	handler.Handle("/validate/azuremachinepool/create", validatorHttpHandlerFactory.NewCreateHandler(azureMachinePoolWebhookHandler))
+	handler.Handle("/validate/azuremachinepool/update", validatorHttpHandlerFactory.NewUpdateHandler(azureMachinePoolWebhookHandler))
 	handler.Handle("/validate/cluster/create", validatorHttpHandlerFactory.NewCreateHandler(clusterWebhookHandler))
 	handler.Handle("/validate/cluster/update", validatorHttpHandlerFactory.NewUpdateHandler(clusterWebhookHandler))
 	handler.Handle("/validate/machinepool/create", validatorHttpHandlerFactory.NewCreateHandler(machinePoolWebhookHandler))

--- a/main.go
+++ b/main.go
@@ -375,7 +375,7 @@ func mainError() error {
 	{
 		c := validator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
-			CtrlCache: ctrlCache,
+			CtrlCache:  ctrlCache,
 		}
 		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -387,6 +387,7 @@ func mainError() error {
 	{
 		c := mutator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
+			CtrlCache:  ctrlCache,
 		}
 		mutatorHttpHandlerFactory, err = mutator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -375,6 +375,7 @@ func mainError() error {
 	{
 		c := validator.HttpHandlerFactoryConfig{
 			CtrlClient: ctrlClient,
+			CtrlCache: ctrlCache,
 		}
 		validatorHttpHandlerFactory, err = validator.NewHttpHandlerFactory(c)
 		if err != nil {

--- a/pkg/azuremachinepool/mutate_create.go
+++ b/pkg/azuremachinepool/mutate_create.go
@@ -5,77 +5,23 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type CreateMutator struct {
-	ctrlClient client.Client
-	location   string
-	logger     micrologger.Logger
-	vmcaps     *vmcapabilities.VMSKU
-}
-
-type CreateMutatorConfig struct {
-	CtrlClient client.Client
-	Location   string
-	Logger     micrologger.Logger
-	VMcaps     *vmcapabilities.VMSKU
-}
-
-func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Location == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.VMcaps == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
-	}
-
-	m := &CreateMutator{
-		ctrlClient: config.CtrlClient,
-		location:   config.Location,
-		logger:     config.Logger,
-		vmcaps:     config.VMcaps,
-	}
-
-	return m, nil
-}
-
-func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnCreateMutate(ctx context.Context, object interface{}) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	azureMPCR := &capzexp.AzureMachinePool{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureMPCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(azureMPCR)
+	azureMPCR, err := key.ToAzureMachinePoolPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
+	azureMPCROriginal := azureMPCR.DeepCopy()
 
-	patch, err := m.ensureLocation(ctx, azureMPCR)
+	patch, err := h.ensureLocation(ctx, azureMPCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -83,7 +29,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = m.ensureStorageAccountType(ctx, azureMPCR)
+	patch, err = h.ensureStorageAccountType(ctx, azureMPCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -91,7 +37,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = m.ensureDataDisks(ctx, azureMPCR)
+	patch, err = h.ensureDataDisks(ctx, azureMPCR)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -99,7 +45,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.EnsureReleaseVersionLabel(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
+	patch, err = mutator.EnsureReleaseVersionLabel(ctx, h.ctrlClient, azureMPCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -107,7 +53,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 		result = append(result, *patch)
 	}
 
-	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, m.ctrlClient, azureMPCR.GetObjectMeta())
+	patch, err = mutator.CopyAzureOperatorVersionLabelFromAzureClusterCR(ctx, h.ctrlClient, azureMPCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -118,7 +64,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	azureMPCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMPCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(azureMPCROriginal, azureMPCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -131,15 +77,7 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	return result, nil
 }
 
-func (m *CreateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *CreateMutator) Resource() string {
-	return "azuremachinepool"
-}
-
-func (m *CreateMutator) ensureStorageAccountType(ctx context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureStorageAccountType(ctx context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
 	if mpCR.Spec.Template.OSDisk.ManagedDisk.StorageAccountType == "" {
 		// We need to set the default value as it is missing.
 
@@ -147,11 +85,11 @@ func (m *CreateMutator) ensureStorageAccountType(ctx context.Context, mpCR *capz
 		if location == "" {
 			// The location was empty and we are adding it using this same mutator.
 			// We assume it will be set to the installation's location.
-			location = m.location
+			location = h.location
 		}
 
 		// Check if the VM has Premium Storage capability.
-		premium, err := m.vmcaps.HasCapability(ctx, location, mpCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
+		premium, err := h.vmcaps.HasCapability(ctx, location, mpCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -171,7 +109,7 @@ func (m *CreateMutator) ensureStorageAccountType(ctx context.Context, mpCR *capz
 	return nil, nil
 }
 
-func (m *CreateMutator) ensureDataDisks(ctx context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureDataDisks(_ context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
 	if len(mpCR.Spec.Template.DataDisks) > 0 {
 		return nil, nil
 	}
@@ -179,10 +117,10 @@ func (m *CreateMutator) ensureDataDisks(ctx context.Context, mpCR *capzexp.Azure
 	return mutator.PatchAdd("/spec/template/dataDisks", desiredDataDisks), nil
 }
 
-func (m *CreateMutator) ensureLocation(ctx context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
+func (h *WebhookHandler) ensureLocation(_ context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
 	if len(mpCR.Spec.Location) > 0 {
 		return nil, nil
 	}
 
-	return mutator.PatchAdd("/spec/location", m.location), nil
+	return mutator.PatchAdd("/spec/location", h.location), nil
 }

--- a/pkg/azuremachinepool/mutate_create_test.go
+++ b/pkg/azuremachinepool/mutate_create_test.go
@@ -10,10 +10,9 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
@@ -25,7 +24,7 @@ import (
 func TestAzureMachinePoolCreateMutate(t *testing.T) {
 	type testCase struct {
 		name         string
-		nodePool     []byte
+		nodePool     *capzexp.AzureMachinePool
 		patches      []mutator.PatchOperation
 		errorMatcher func(err error) bool
 	}
@@ -33,7 +32,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:     "case 0: unset storage account type with premium VM",
-			nodePool: builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4s_v3"), builder.StorageAccountType("")),
+			nodePool: builder.BuildAzureMachinePool(builder.VMSize("Standard_D4s_v3"), builder.StorageAccountType("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -45,7 +44,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 1: unset storage account type with standard VM",
-			nodePool: builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.StorageAccountType("")),
+			nodePool: builder.BuildAzureMachinePool(builder.VMSize("Standard_D4_v3"), builder.StorageAccountType("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -57,7 +56,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 2: set data disks",
-			nodePool: builder.BuildAzureMachinePoolAsJson(builder.DataDisks([]capz.DataDisk{})),
+			nodePool: builder.BuildAzureMachinePool(builder.DataDisks([]capz.DataDisk{})),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -69,7 +68,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 		},
 		{
 			name:     "case 3: set location",
-			nodePool: builder.BuildAzureMachinePoolAsJson(builder.Location("")),
+			nodePool: builder.BuildAzureMachinePool(builder.Location("")),
 			patches: []mutator.PatchOperation{
 				{
 					Operation: "add",
@@ -184,15 +183,18 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			admit := &CreateMutator{
-				ctrlClient: ctrlClient,
-				location:   "westeurope",
-				logger:     newLogger,
-				vmcaps:     vmcaps,
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Location:   "westeurope",
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			patches, err := admit.Mutate(context.Background(), getCreateMutateAdmissionRequest(tc.nodePool))
+			// Run mutating webhook handler on AzureMachinePool creation.
+			patches, err := handler.OnCreateMutate(ctx, tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -212,20 +214,4 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getCreateMutateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azuremachinepool",
-		},
-		Operation: v1beta1.Create,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/azuremachinepool/mutate_create_test.go
+++ b/pkg/azuremachinepool/mutate_create_test.go
@@ -185,6 +185,7 @@ func TestAzureMachinePoolCreateMutate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Location:   "westeurope",
 				Logger:     newLogger,
 				VMcaps:     vmcaps,

--- a/pkg/azuremachinepool/mutate_update.go
+++ b/pkg/azuremachinepool/mutate_update.go
@@ -4,68 +4,25 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-admission-controller/internal/patches"
-	"github.com/giantswarm/azure-admission-controller/pkg/generic"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type UpdateMutator struct {
-	ctrlClient ctrl.Client
-	logger     micrologger.Logger
-}
-
-type UpdateMutatorConfig struct {
-	CtrlClient ctrl.Client
-	Logger     micrologger.Logger
-}
-
-func NewUpdateMutator(config UpdateMutatorConfig) (*UpdateMutator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	m := &UpdateMutator{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return m, nil
-}
-
-func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnUpdateMutate(_ context.Context, _ interface{}, object interface{}) ([]mutator.PatchOperation, error) {
 	var err error
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
-	}
-
-	azureMPCR := &capzexp.AzureMachinePool{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, azureMPCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(azureMPCR)
+	azureMPCR, err := key.ToAzureMachinePoolPtr(object)
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
-	if capi {
-		return []mutator.PatchOperation{}, nil
-	}
+	azureMPCROriginal := azureMPCR.DeepCopy()
 
 	azureMPCR.Default()
 	{
 		var capiPatches []mutator.PatchOperation
-		capiPatches, err = patches.GenerateFrom(request.Object.Raw, azureMPCR)
+		capiPatches, err = patches.GenerateFromObjectDiff(azureMPCROriginal, azureMPCR)
 		if err != nil {
 			return []mutator.PatchOperation{}, microerror.Mask(err)
 		}
@@ -76,12 +33,4 @@ func (m *UpdateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 
 	return result, nil
-}
-
-func (m *UpdateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *UpdateMutator) Resource() string {
-	return "azurecluster"
 }

--- a/pkg/azuremachinepool/validate_create.go
+++ b/pkg/azuremachinepool/validate_create.go
@@ -4,66 +4,15 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type CreateValidator struct {
-	ctrlClient client.Client
-	location   string
-	logger     micrologger.Logger
-	vmcaps     *vmcapabilities.VMSKU
-}
-
-type CreateValidatorConfig struct {
-	CtrlClient client.Client
-	Location   string
-	Logger     micrologger.Logger
-	VMcaps     *vmcapabilities.VMSKU
-}
-
-func NewCreateValidator(config CreateValidatorConfig) (*CreateValidator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Location == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.VMcaps == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
-	}
-
-	admitter := &CreateValidator{
-		ctrlClient: config.CtrlClient,
-		location:   config.Location,
-		logger:     config.Logger,
-		vmcaps:     config.VMcaps,
-	}
-
-	return admitter, nil
-}
-
-func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	azureMPNewCR := &capzexp.AzureMachinePool{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureMPNewCR); err != nil {
-		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
-	}
-
-	capi, err := generic.IsCAPIRelease(azureMPNewCR)
+func (h *WebhookHandler) OnCreateValidate(ctx context.Context, object interface{}) error {
+	azureMPNewCR, err := key.ToAzureMachinePoolPtr(object)
 	if err != nil {
 		return microerror.Mask(err)
-	}
-	if capi {
-		return nil
 	}
 
 	err = azureMPNewCR.ValidateCreate()
@@ -71,22 +20,22 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = generic.ValidateOrganizationLabelMatchesCluster(ctx, a.ctrlClient, azureMPNewCR)
+	err = generic.ValidateOrganizationLabelMatchesCluster(ctx, h.ctrlClient, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = checkInstanceTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
+	err = checkInstanceTypeIsValid(ctx, h.vmcaps, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = checkAcceleratedNetworking(ctx, a.vmcaps, azureMPNewCR)
+	err = checkAcceleratedNetworking(ctx, h.vmcaps, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = checkStorageAccountTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
+	err = checkStorageAccountTypeIsValid(ctx, h.vmcaps, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -101,14 +50,10 @@ func (a *CreateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = checkLocation(*azureMPNewCR, a.location)
+	err = checkLocation(*azureMPNewCR, h.location)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	return nil
-}
-
-func (a *CreateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
 }

--- a/pkg/azuremachinepool/validate_create_test.go
+++ b/pkg/azuremachinepool/validate_create_test.go
@@ -258,6 +258,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Location:   "westeurope",
 				Logger:     newLogger,
 				VMcaps:     vmcaps,

--- a/pkg/azuremachinepool/validate_create_test.go
+++ b/pkg/azuremachinepool/validate_create_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
@@ -33,7 +32,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	}
 	type testCase struct {
 		name         string
-		nodePool     []byte
+		nodePool     *capzexp.AzureMachinePool
 		errorMatcher func(err error) bool
 	}
 
@@ -42,19 +41,19 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	for i, instanceType := range unsupportedInstanceType {
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", i*3, instanceType),
-			nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			nodePool:     builder.BuildAzureMachinePool(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsVmsizeDoesNotSupportAcceleratedNetworkingError,
 		})
 
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking disabled", i*3+1, instanceType),
-			nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			nodePool:     builder.BuildAzureMachinePool(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: nil,
 		})
 
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking nil", i*3+2, instanceType),
-			nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize(instanceType), builder.AcceleratedNetworking(nil)),
+			nodePool:     builder.BuildAzureMachinePool(builder.VMSize(instanceType), builder.AcceleratedNetworking(nil)),
 			errorMatcher: nil,
 		})
 	}
@@ -64,7 +63,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 		instanceType := "this_is_a_random_name"
 		testCases = append(testCases, testCase{
 			name:         fmt.Sprintf("case %d: instance type %s with accelerated networking enabled", len(testCases), instanceType),
-			nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			nodePool:     builder.BuildAzureMachinePool(builder.VMSize(instanceType), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: vmcapabilities.IsSkuNotFoundError,
 		})
 	}
@@ -72,7 +71,7 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 	{
 		testCases = append(testCases, testCase{
 			name: fmt.Sprintf("case %d: data disks already set", len(testCases)),
-			nodePool: builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.DataDisks([]capz.DataDisk{
+			nodePool: builder.BuildAzureMachinePool(builder.VMSize("Standard_D4_v3"), builder.DataDisks([]capz.DataDisk{
 				{
 					NameSuffix: "docker",
 					DiskSizeGB: 50,
@@ -90,13 +89,13 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 
 	testCases = append(testCases, testCase{
 		name:         fmt.Sprintf("case %d: invalid location", len(testCases)-1),
-		nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.Location("eastgalicia")),
+		nodePool:     builder.BuildAzureMachinePool(builder.VMSize("Standard_D4_v3"), builder.Location("eastgalicia")),
 		errorMatcher: IsUnexpectedLocationError,
 	})
 
 	testCases = append(testCases, testCase{
 		name:         fmt.Sprintf("case %d: invalid organization", len(testCases)-1),
-		nodePool:     builder.BuildAzureMachinePoolAsJson(builder.VMSize("Standard_D4_v3"), builder.Organization("wrongorg")),
+		nodePool:     builder.BuildAzureMachinePool(builder.VMSize("Standard_D4_v3"), builder.Organization("wrongorg")),
 		errorMatcher: generic.IsNodepoolOrgDoesNotMatchClusterOrg,
 	})
 
@@ -257,15 +256,18 @@ func TestAzureMachinePoolCreateValidate(t *testing.T) {
 				panic(microerror.JSON(err))
 			}
 
-			admit := &CreateValidator{
-				ctrlClient: ctrlClient,
-				location:   "westeurope",
-				logger:     newLogger,
-				vmcaps:     vmcaps,
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Location:   "westeurope",
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			err = admit.Validate(ctx, getCreateAdmissionRequest(tc.nodePool))
+			// Run validating webhook handler on AzureMachinePool creation.
+			err = handler.OnCreateValidate(ctx, tc.nodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -292,20 +294,4 @@ func NewStubAPI(stubbedSKUs map[string]compute.ResourceSku) vmcapabilities.API {
 
 func (s *StubAPI) List(ctx context.Context, filter string) (map[string]compute.ResourceSku, error) {
 	return s.stubbedSKUs, nil
-}
-
-func getCreateAdmissionRequest(newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azuremachinepool",
-		},
-		Operation: v1beta1.Create,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }

--- a/pkg/azuremachinepool/validate_update.go
+++ b/pkg/azuremachinepool/validate_update.go
@@ -4,54 +4,26 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
 	"github.com/giantswarm/azure-admission-controller/pkg/generic"
-	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 )
 
-type UpdateValidator struct {
-	logger micrologger.Logger
-	vmcaps *vmcapabilities.VMSKU
-}
-
-type UpdateValidatorConfig struct {
-	Logger micrologger.Logger
-	VMcaps *vmcapabilities.VMSKU
-}
-
-func NewUpdateValidator(config UpdateValidatorConfig) (*UpdateValidator, error) {
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+func (h *WebhookHandler) OnUpdateValidate(ctx context.Context, oldObject interface{}, object interface{}) error {
+	azureMPNewCR, err := key.ToAzureMachinePoolPtr(object)
+	if err != nil {
+		return microerror.Mask(err)
 	}
-	if config.VMcaps == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
-	}
-
-	admitter := &UpdateValidator{
-		logger: config.Logger,
-		vmcaps: config.VMcaps,
-	}
-
-	return admitter, nil
-}
-
-func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.AdmissionRequest) error {
-	azureMPNewCR := &capzexp.AzureMachinePool{}
-	azureMPOldCR := &capzexp.AzureMachinePool{}
-	if _, _, err := validator.Deserializer.Decode(request.Object.Raw, nil, azureMPNewCR); err != nil {
-		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
-	}
-	if _, _, err := validator.Deserializer.Decode(request.OldObject.Raw, nil, azureMPOldCR); err != nil {
-		return microerror.Maskf(parsingFailedError, "unable to parse azureMachinePool CR: %v", err)
-	}
-
 	if !azureMPNewCR.GetDeletionTimestamp().IsZero() {
-		a.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
+		h.logger.LogCtx(ctx, "level", "debug", "message", "The object is being deleted so we don't validate it")
 		return nil
+	}
+
+	azureMPOldCR, err := key.ToAzureMachinePoolPtr(oldObject)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
 	capi, err := generic.IsCAPIRelease(azureMPNewCR)
@@ -72,27 +44,27 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 		return microerror.Mask(err)
 	}
 
-	err = checkInstanceTypeIsValid(ctx, a.vmcaps, azureMPNewCR)
+	err = checkInstanceTypeIsValid(ctx, h.vmcaps, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = a.checkAcceleratedNetworkingUpdateIsValid(ctx, azureMPOldCR, azureMPNewCR)
+	err = h.checkAcceleratedNetworkingUpdateIsValid(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = a.checkInstanceTypeChangeIsValid(ctx, azureMPOldCR, azureMPNewCR)
+	err = h.checkInstanceTypeChangeIsValid(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = a.checkSpotVMOptionsUnchanged(ctx, azureMPOldCR, azureMPNewCR)
+	err = h.checkSpotVMOptionsUnchanged(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = a.checkStorageAccountTypeUnchanged(ctx, azureMPOldCR, azureMPNewCR)
+	err = h.checkStorageAccountTypeUnchanged(ctx, azureMPOldCR, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -115,7 +87,7 @@ func (a *UpdateValidator) Validate(ctx context.Context, request *v1beta1.Admissi
 	return nil
 }
 
-func (a *UpdateValidator) checkAcceleratedNetworkingUpdateIsValid(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
+func (h *WebhookHandler) checkAcceleratedNetworkingUpdateIsValid(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
 	if hasAcceleratedNetworkingPropertyChanged(ctx, azureMPOldCR, azureMPNewCR) {
 		return microerror.Maskf(acceleratedNetworkingWasChangedError, "It is not possible to change the AcceleratedNetworking on an existing node pool")
 	}
@@ -124,7 +96,7 @@ func (a *UpdateValidator) checkAcceleratedNetworkingUpdateIsValid(ctx context.Co
 		return nil
 	}
 
-	err := checkAcceleratedNetworking(ctx, a.vmcaps, azureMPNewCR)
+	err := checkAcceleratedNetworking(ctx, h.vmcaps, azureMPNewCR)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -132,14 +104,14 @@ func (a *UpdateValidator) checkAcceleratedNetworkingUpdateIsValid(ctx context.Co
 	return nil
 }
 
-func (a *UpdateValidator) checkInstanceTypeChangeIsValid(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
+func (h *WebhookHandler) checkInstanceTypeChangeIsValid(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
 	// Check if the instance type has changed.
 	if azureMPOldCR.Spec.Template.VMSize != azureMPNewCR.Spec.Template.VMSize {
-		oldPremium, err := a.vmcaps.HasCapability(ctx, azureMPOldCR.Spec.Location, azureMPOldCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
+		oldPremium, err := h.vmcaps.HasCapability(ctx, azureMPOldCR.Spec.Location, azureMPOldCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		newPremium, err := a.vmcaps.HasCapability(ctx, azureMPNewCR.Spec.Location, azureMPNewCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
+		newPremium, err := h.vmcaps.HasCapability(ctx, azureMPNewCR.Spec.Location, azureMPNewCR.Spec.Template.VMSize, vmcapabilities.CapabilityPremiumIO)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -154,7 +126,7 @@ func (a *UpdateValidator) checkInstanceTypeChangeIsValid(ctx context.Context, az
 	return nil
 }
 
-func (a *UpdateValidator) checkSpotVMOptionsUnchanged(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
+func (h *WebhookHandler) checkSpotVMOptionsUnchanged(_ context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
 
 	switch {
 	case (azureMPOldCR.Spec.Template.SpotVMOptions == nil && azureMPNewCR.Spec.Template.SpotVMOptions == nil):
@@ -177,14 +149,10 @@ func (a *UpdateValidator) checkSpotVMOptionsUnchanged(ctx context.Context, azure
 }
 
 // Checks if the storage account type of the osDisk is changed. This is never allowed.
-func (a *UpdateValidator) checkStorageAccountTypeUnchanged(ctx context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
+func (h *WebhookHandler) checkStorageAccountTypeUnchanged(_ context.Context, azureMPOldCR *capzexp.AzureMachinePool, azureMPNewCR *capzexp.AzureMachinePool) error {
 	if azureMPOldCR.Spec.Template.OSDisk.ManagedDisk.StorageAccountType != azureMPNewCR.Spec.Template.OSDisk.ManagedDisk.StorageAccountType {
 		return microerror.Maskf(storageAccountWasChangedError, "Changing the storage account type of the OS disk is not allowed.")
 	}
 
 	return nil
-}
-
-func (a *UpdateValidator) Log(keyVals ...interface{}) {
-	a.logger.Log(keyVals...)
 }

--- a/pkg/azuremachinepool/validate_update_test.go
+++ b/pkg/azuremachinepool/validate_update_test.go
@@ -294,6 +294,7 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 
 			handler, err := NewWebhookHandler(WebhookHandlerConfig{
 				CtrlClient: ctrlClient,
+				Decoder:    unittest.NewFakeDecoder(),
 				Location:   "westeurope",
 				Logger:     newLogger,
 				VMcaps:     vmcaps,

--- a/pkg/azuremachinepool/validate_update_test.go
+++ b/pkg/azuremachinepool/validate_update_test.go
@@ -8,14 +8,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 
 	builder "github.com/giantswarm/azure-admission-controller/internal/test/azuremachinepool"
 	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/unittest"
 )
 
 func TestAzureMachinePoolUpdateValidate(t *testing.T) {
@@ -30,94 +29,94 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 	standardStorageInstanceType := "Standard_D4_v3"
 	type testCase struct {
 		name         string
-		oldNodePool  []byte
-		newNodePool  []byte
+		oldNodePool  *capzexp.AzureMachinePool
+		newNodePool  *capzexp.AzureMachinePool
 		errorMatcher func(err error) bool
 	}
 
 	testCases := []testCase{
 		{
 			name:         "case 0: AcceleratedNetworking is enabled in CR and we don't change it or the instance type",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 1: AcceleratedNetworking is disabled in CR and we don't change it or the instance type",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 2: Enabled and try disabling it, keeping same instance type",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 3: Enabled, try updating to new instance type that supports it",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[1]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[1]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 4: Enabled, try updating to new instance type that does NOT supports it",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(unsupportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(unsupportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsVmsizeDoesNotSupportAcceleratedNetworkingError,
 		},
 		{
 			name:         "case 5: Disabled and try enabling it",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 6: changed from nil to true",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 7: changed from true to nil",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(true))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 8: changed from nil to false",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 9: changed from false to nil",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(to.BoolPtr(false))),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(supportedInstanceType[0]), builder.AcceleratedNetworking(nil)),
 			errorMatcher: IsAcceleratedNetworkingWasChangedError,
 		},
 		{
 			name:         "case 10: changed from premium to standard storage",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(premiumStorageInstanceType)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(standardStorageInstanceType)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(premiumStorageInstanceType)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(standardStorageInstanceType)),
 			errorMatcher: IsSwitchToVmSizeThatDoesNotSupportAcceleratedNetworkingError,
 		},
 		{
 			name:         "case 11: changed from standard to premium storage",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(standardStorageInstanceType)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.VMSize(premiumStorageInstanceType)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.VMSize(standardStorageInstanceType)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.VMSize(premiumStorageInstanceType)),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 12: change storage account type",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.StorageAccountType(compute.StorageAccountTypesStandardLRS)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.StorageAccountType(compute.StorageAccountTypesPremiumLRS)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.StorageAccountType(compute.StorageAccountTypesStandardLRS)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.StorageAccountType(compute.StorageAccountTypesPremiumLRS)),
 			errorMatcher: IsStorageAccountWasChangedError,
 		},
 		{
 			name:        "case 13: change datadisks",
-			oldNodePool: builder.BuildAzureMachinePoolAsJson(),
-			newNodePool: builder.BuildAzureMachinePoolAsJson(builder.DataDisks([]capz.DataDisk{
+			oldNodePool: builder.BuildAzureMachinePool(),
+			newNodePool: builder.BuildAzureMachinePool(builder.DataDisks([]capz.DataDisk{
 				{
 					NameSuffix: "docker",
 					DiskSizeGB: 30,
@@ -133,50 +132,50 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 		},
 		{
 			name:         "case 14: changed location",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("westeurope")),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("northeastitaly")),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.Location("westeurope")),
+			newNodePool:  builder.BuildAzureMachinePool(builder.Location("northeastitaly")),
 			errorMatcher: IsLocationWasChangedError,
 		},
 		{
 			name:         "case 15: disable spot instance configuration",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(nil)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(nil)),
 			errorMatcher: IsSpotVMOptionsWasChangedError,
 		},
 		{
 			name:         "case 16: enable spot instance configuration",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(nil)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(nil)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
 			errorMatcher: IsSpotVMOptionsWasChangedError,
 		},
 		{
 			name:         "case 17: change spot instance price configuration",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("-1")})),
 			errorMatcher: IsSpotVMOptionsWasChangedError,
 		},
 		{
 			name:         "case 18: keep spot instances disabled",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(nil)),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(nil)),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(nil)),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(nil)),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 19: keep spot instances price configuration unknown",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: nil})),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: nil})),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: nil})),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: nil})),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 20: keep spot instances price configuration unchanged",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
+			newNodePool:  builder.BuildAzureMachinePool(builder.SpotVMOptions(&capz.SpotVMOptions{MaxPrice: toQuantityPtr("1.24322")})),
 			errorMatcher: nil,
 		},
 		{
 			name:         "case 21: changed location but object is being deleted",
-			oldNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("westeurope")),
-			newNodePool:  builder.BuildAzureMachinePoolAsJson(builder.Location("northeastitaly"), builder.WithDeletionTimestamp()),
+			oldNodePool:  builder.BuildAzureMachinePool(builder.Location("westeurope")),
+			newNodePool:  builder.BuildAzureMachinePool(builder.Location("northeastitaly"), builder.WithDeletionTimestamp()),
 			errorMatcher: nil,
 		},
 	}
@@ -193,6 +192,11 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 					panic(microerror.JSON(err))
 				}
 			}
+
+			ctx := context.Background()
+			fakeK8sClient := unittest.FakeK8sClient()
+			ctrlClient := fakeK8sClient.CtrlClient()
+
 			stubbedSKUs := map[string]compute.ResourceSku{
 				"Standard_D4_v3": {
 					Name: to.StringPtr("Standard_D4_v3"),
@@ -288,13 +292,18 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 				panic(microerror.JSON(err))
 			}
 
-			admit := &UpdateValidator{
-				logger: newLogger,
-				vmcaps: vmcaps,
+			handler, err := NewWebhookHandler(WebhookHandlerConfig{
+				CtrlClient: ctrlClient,
+				Location:   "westeurope",
+				Logger:     newLogger,
+				VMcaps:     vmcaps,
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
 
-			// Run admission request to validate AzureConfig updates.
-			err = admit.Validate(context.Background(), getUpdateAdmissionRequest(tc.oldNodePool, tc.newNodePool))
+			// Run validating webhook handler on AzureMachinePool update.
+			err = handler.OnUpdateValidate(ctx, tc.oldNodePool, tc.newNodePool)
 
 			// Check if the error is the expected one.
 			switch {
@@ -309,26 +318,6 @@ func TestAzureMachinePoolUpdateValidate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func getUpdateAdmissionRequest(oldMP []byte, newMP []byte) *v1beta1.AdmissionRequest {
-	req := &v1beta1.AdmissionRequest{
-		Resource: metav1.GroupVersionResource{
-			Version:  "exp.infrastructure.cluster.x-k8s.io/v1alpha3",
-			Resource: "azuremachinepool",
-		},
-		Operation: v1beta1.Update,
-		Object: runtime.RawExtension{
-			Raw:    newMP,
-			Object: nil,
-		},
-		OldObject: runtime.RawExtension{
-			Raw:    oldMP,
-			Object: nil,
-		},
-	}
-
-	return req
 }
 
 func toQuantityPtr(d string) *resource.Quantity {

--- a/pkg/azuremachinepool/webhook_handler.go
+++ b/pkg/azuremachinepool/webhook_handler.go
@@ -1,0 +1,69 @@
+package azuremachinepool
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/internal/vmcapabilities"
+	"github.com/giantswarm/azure-admission-controller/pkg/validator"
+)
+
+type WebhookHandler struct {
+	ctrlClient client.Client
+	location   string
+	logger     micrologger.Logger
+	vmcaps     *vmcapabilities.VMSKU
+}
+
+type WebhookHandlerConfig struct {
+	CtrlClient client.Client
+	Location   string
+	Logger     micrologger.Logger
+	VMcaps     *vmcapabilities.VMSKU
+}
+
+func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Location == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.VMcaps == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VMcaps must not be empty", config)
+	}
+
+	handler := &WebhookHandler{
+		ctrlClient: config.CtrlClient,
+		location:   config.Location,
+		logger:     config.Logger,
+		vmcaps:     config.VMcaps,
+	}
+
+	return handler, nil
+}
+
+func (h *WebhookHandler) Log(keyVals ...interface{}) {
+	h.logger.Log(keyVals...)
+}
+
+func (h *WebhookHandler) Resource() string {
+	return "azuremachinepool"
+}
+
+func (h *WebhookHandler) Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error) {
+	cr := &capzexp.AzureMachinePool{}
+	if _, _, err := validator.Deserializer.Decode(rawObject.Raw, nil, cr); err != nil {
+		return nil, microerror.Maskf(errors.ParsingFailedError, "unable to parse AzureMachinePool CR: %v", err)
+	}
+
+	return cr, nil
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
@@ -82,6 +83,19 @@ func ToMachinePoolPtr(v interface{}) (*capiexp.MachinePool, error) {
 	customObjectPointer, ok := v.(*capiexp.MachinePool)
 	if !ok {
 		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capiexp.MachinePool{}, v)
+	}
+
+	return customObjectPointer, nil
+}
+
+func ToAzureMachinePoolPtr(v interface{}) (*capzexp.AzureMachinePool, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capzexp.AzureMachinePool{}, v)
+	}
+
+	customObjectPointer, ok := v.(*capzexp.AzureMachinePool)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capzexp.AzureMachinePool{}, v)
 	}
 
 	return customObjectPointer, nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `AzureMachinePool` CRD:
- `mutator.WebhookCreateHandler`
- `mutator.WebhookUpdateHandler`
- `validator.WebhookCreateHandler`
- `validator.WebhookUpdateHandler`

The implementation of these interfaces will replace current `CreateMutator`, `UpdateMutator`, `CreateValidator` and `UpdateValidator`. The important part here is that the mutation and validation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `AzureMachinePool` to use new `WebhookHandler` implementations
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementations
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster https://github.com/giantswarm/azure-admission-controller/pull/272
- AzureCluster https://github.com/giantswarm/azure-admission-controller/pull/273
- MachinePool https://github.com/giantswarm/azure-admission-controller/pull/274
- AzureMachinePool _(this PR)_
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark https://github.com/giantswarm/azure-admission-controller/pull/279
- AzureClusterConfig https://github.com/giantswarm/azure-admission-controller/pull/280
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281