### PR TITLE
Add spark.WebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MachinePool webhook handler that replaces mutators and validators.
 - AzureMachinePool webhook handler that replaces mutators and validators.
 - AzureMachine webhook handler that replaces mutators and validators.
+- Spark webhook handler that replaces mutator.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -266,6 +266,7 @@ func mainError() error {
 	{
 		c := spark.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
+			Decoder:    universalDeserializer,
 			Logger:     newLogger,
 		}
 		sparkWebhookHandler, err = spark.NewWebhookHandler(c)

--- a/main.go
+++ b/main.go
@@ -262,13 +262,13 @@ func mainError() error {
 		}
 	}
 
-	var sparkCreateMutator *spark.CreateMutator
+	var sparkWebhookHandler *spark.WebhookHandler
 	{
-		c := spark.CreateMutatorConfig{
+		c := spark.WebhookHandlerConfig{
 			CtrlClient: ctrlClient,
 			Logger:     newLogger,
 		}
-		sparkCreateMutator, err = spark.NewCreateMutator(c)
+		sparkWebhookHandler, err = spark.NewWebhookHandler(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -311,7 +311,7 @@ func mainError() error {
 	handler.Handle("/mutate/cluster/update", mutatorHttpHandlerFactory.NewUpdateHandler(clusterWebhookHandler))
 	handler.Handle("/mutate/machinepool/create", mutatorHttpHandlerFactory.NewCreateHandler(machinePoolWebhookHandler))
 	handler.Handle("/mutate/machinepool/update", mutatorHttpHandlerFactory.NewUpdateHandler(machinePoolWebhookHandler))
-	handler.Handle("/mutate/spark/create", mutator.Handler(sparkCreateMutator))
+	handler.Handle("/mutate/spark/create", mutatorHttpHandlerFactory.NewCreateHandler(sparkWebhookHandler))
 
 	// Validators.
 	handler.Handle("/validate/azureconfig/update", validator.Handler(azureConfigValidator))

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -3,6 +3,7 @@ package key
 import (
 	"fmt"
 
+	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
@@ -109,6 +110,19 @@ func ToAzureMachinePtr(v interface{}) (*capz.AzureMachine, error) {
 	customObjectPointer, ok := v.(*capz.AzureMachine)
 	if !ok {
 		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &capz.AzureMachine{}, v)
+	}
+
+	return customObjectPointer, nil
+}
+
+func ToSparkPtr(v interface{}) (*corev1alpha1v3.Spark, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &corev1alpha1v3.Spark{}, v)
+	}
+
+	customObjectPointer, ok := v.(*corev1alpha1v3.Spark)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &corev1alpha1v3.Spark{}, v)
 	}
 
 	return customObjectPointer, nil

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
+<<<<<<< HEAD
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+=======
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+>>>>>>> 97b924b... Replace Cluster mutators and validators with a webhook handler
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -4,14 +4,10 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-<<<<<<< HEAD
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-=======
-	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
->>>>>>> 97b924b... Replace Cluster mutators and validators with a webhook handler
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )

--- a/pkg/spark/mutate_create.go
+++ b/pkg/spark/mutate_create.go
@@ -3,56 +3,20 @@ package spark
 import (
 	"context"
 
-	"github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/micrologger"
-	"k8s.io/api/admission/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/pkg/key"
 	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
 )
 
-type CreateMutator struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
-}
-
-type CreateMutatorConfig struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-}
-
-func NewCreateMutator(config CreateMutatorConfig) (*CreateMutator, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	m := &CreateMutator{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-	}
-
-	return m, nil
-}
-
-func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRequest) ([]mutator.PatchOperation, error) {
+func (h *WebhookHandler) OnCreateMutate(ctx context.Context, object interface{}) ([]mutator.PatchOperation, error) {
 	var result []mutator.PatchOperation
-
-	if request.DryRun != nil && *request.DryRun {
-		m.logger.LogCtx(ctx, "level", "debug", "message", "Dry run is not supported. Request processing stopped.")
-		return result, nil
+	sparkCR, err := key.ToSparkPtr(object)
+	if err != nil {
+		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
 
-	sparkCR := &v1alpha1.Spark{}
-	if _, _, err := mutator.Deserializer.Decode(request.Object.Raw, nil, sparkCR); err != nil {
-		return []mutator.PatchOperation{}, microerror.Maskf(errors.ParsingFailedError, "unable to parse Spark CR: %v", err)
-	}
-
-	patch, err := mutator.EnsureReleaseVersionLabel(ctx, m.ctrlClient, sparkCR.GetObjectMeta())
+	patch, err := mutator.EnsureReleaseVersionLabel(ctx, h.ctrlClient, sparkCR.GetObjectMeta())
 	if err != nil {
 		return []mutator.PatchOperation{}, microerror.Mask(err)
 	}
@@ -61,12 +25,4 @@ func (m *CreateMutator) Mutate(ctx context.Context, request *v1beta1.AdmissionRe
 	}
 
 	return result, nil
-}
-
-func (m *CreateMutator) Log(keyVals ...interface{}) {
-	m.logger.Log(keyVals...)
-}
-
-func (m *CreateMutator) Resource() string {
-	return "spark"
 }

--- a/pkg/spark/webhook_handler.go
+++ b/pkg/spark/webhook_handler.go
@@ -14,11 +14,13 @@ import (
 
 type WebhookHandler struct {
 	ctrlClient client.Client
+	decoder    runtime.Decoder
 	logger     micrologger.Logger
 }
 
 type WebhookHandlerConfig struct {
 	CtrlClient client.Client
+	Decoder    runtime.Decoder
 	Logger     micrologger.Logger
 }
 
@@ -26,12 +28,16 @@ func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
 	if config.CtrlClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
 	}
+	if config.Decoder == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Decoder must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
 	m := &WebhookHandler{
 		ctrlClient: config.CtrlClient,
+		decoder:    config.Decoder,
 		logger:     config.Logger,
 	}
 

--- a/pkg/spark/webhook_handler.go
+++ b/pkg/spark/webhook_handler.go
@@ -1,0 +1,56 @@
+package spark
+
+import (
+	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-admission-controller/internal/errors"
+	"github.com/giantswarm/azure-admission-controller/pkg/mutator"
+)
+
+type WebhookHandler struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+type WebhookHandlerConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+func NewWebhookHandler(config WebhookHandlerConfig) (*WebhookHandler, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	m := &WebhookHandler{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return m, nil
+}
+
+func (h *WebhookHandler) Log(keyVals ...interface{}) {
+	h.logger.Log(keyVals...)
+}
+
+func (h *WebhookHandler) Resource() string {
+	return "spark"
+}
+
+func (h *WebhookHandler) Decode(rawObject runtime.RawExtension) (metav1.ObjectMetaAccessor, error) {
+	sparkCR := &corev1alpha1v3.Spark{}
+	if _, _, err := mutator.Deserializer.Decode(rawObject.Raw, nil, sparkCR); err != nil {
+		return nil, microerror.Maskf(errors.ParsingFailedError, "unable to parse Spark CR: %v", err)
+	}
+
+	return sparkCR, nil
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `Spark` CRD:
- `mutator.WebhookCreateHandler`

The implementation of this interface will replace current `CreateMutator`. The important part here is that the mutation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `Spark` to use new `WebhookHandler` implementation
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementation
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster https://github.com/giantswarm/azure-admission-controller/pull/272
- AzureCluster https://github.com/giantswarm/azure-admission-controller/pull/273
- MachinePool https://github.com/giantswarm/azure-admission-controller/pull/274
- AzureMachinePool https://github.com/giantswarm/azure-admission-controller/pull/275
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark _(this PR)_
- AzureClusterConfig https://github.com/giantswarm/azure-admission-controller/pull/280
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281