### PR TITLE
Add azureupdate.AzureClusterConfigWebhookHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AzureMachinePool webhook handler that replaces mutators and validators.
 - AzureMachine webhook handler that replaces mutators and validators.
 - Spark webhook handler that replaces mutator.
+- AzureClusterConfig webhook handler that replaces validator.
 
 ### Changed
 

--- a/main.go
+++ b/main.go
@@ -191,13 +191,14 @@ func mainError() error {
 		}
 	}
 
-	var azureClusterConfigValidator *azureupdate.AzureClusterConfigValidator
+	var azureClusterConfigValidator *azureupdate.AzureClusterConfigWebhookHandler
 	{
-		azureClusterConfigValidatorConfig := azureupdate.AzureClusterConfigValidatorConfig{
+		c := azureupdate.AzureClusterConfigWebhookHandlerConfig{
 			CtrlClient: ctrlClient,
+			Decoder:    universalDeserializer,
 			Logger:     newLogger,
 		}
-		azureClusterConfigValidator, err = azureupdate.NewAzureClusterConfigValidator(azureClusterConfigValidatorConfig)
+		azureClusterConfigValidator, err = azureupdate.NewAzureClusterConfigWebhookHandler(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -316,7 +317,7 @@ func mainError() error {
 
 	// Validators.
 	handler.Handle("/validate/azureconfig/update", validator.Handler(azureConfigValidator))
-	handler.Handle("/validate/azureclusterconfig/update", validator.Handler(azureClusterConfigValidator))
+	handler.Handle("/validate/azureclusterconfig/update", validatorHttpHandlerFactory.NewUpdateHandler(azureClusterConfigValidator))
 	handler.Handle("/validate/azurecluster/create", validatorHttpHandlerFactory.NewCreateHandler(azureClusterWebhookHandler))
 	handler.Handle("/validate/azurecluster/update", validatorHttpHandlerFactory.NewUpdateHandler(azureClusterWebhookHandler))
 	handler.Handle("/validate/azuremachine/create", validatorHttpHandlerFactory.NewCreateHandler(azureMachineWebhookHandler))

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,10 +5,14 @@ import (
 
 	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
+<<<<<<< HEAD
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+=======
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+>>>>>>> 97b924b... Replace Cluster mutators and validators with a webhook handler
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -5,14 +5,10 @@ import (
 
 	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
-<<<<<<< HEAD
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-=======
-	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
->>>>>>> 97b924b... Replace Cluster mutators and validators with a webhook handler
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 )

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -6,7 +6,10 @@ import (
 	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+<<<<<<< HEAD
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+=======
+>>>>>>> 24c7d66... Replace AzureCluster mutators and validators with a webhook handler
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -127,3 +127,16 @@ func ToSparkPtr(v interface{}) (*corev1alpha1v3.Spark, error) {
 
 	return customObjectPointer, nil
 }
+
+func ToAzureClusterConfigPtr(v interface{}) (*corev1alpha1v3.AzureClusterConfig, error) {
+	if v == nil {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &corev1alpha1v3.AzureClusterConfig{}, v)
+	}
+
+	customObjectPointer, ok := v.(*corev1alpha1v3.AzureClusterConfig)
+	if !ok {
+		return nil, microerror.Maskf(errors.WrongTypeError, "expected '%T', got '%T'", &corev1alpha1v3.AzureClusterConfig{}, v)
+	}
+
+	return customObjectPointer, nil
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -6,10 +6,7 @@ import (
 	corev1alpha1v3 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-<<<<<<< HEAD
 	capzexp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-=======
->>>>>>> 24c7d66... Replace AzureCluster mutators and validators with a webhook handler
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17957

## Motivation

Here https://github.com/giantswarm/azure-admission-controller/pull/268 we have introduced a new HTTP handler factory that is creating new handlers that are using new `WebhookHandler` interfaces and which are making use of CR filtering functionality that is introduced here https://github.com/giantswarm/azure-admission-controller/pull/247.

Now it's time to put all of that into action and actually start using it in azure-admission-controller.

P.S. We are doing all of this so that azure-admission-controller is only validating and mutating the CRs that belong to legacy Giant Swarm releases. New CRs from new CAPI releases will be validated and mutated by new admission controllers.

## Implementation

This pull request adds implementation of these interfaces for the `AzureClusterConfig` CRD:
- `validator.WebhookUpdateHandler`

The implementation of these interfaces will replace current `UpdateValidator`. The important part here is that the mutation and validation logic remains exactly the same, it's just refactored significantly in order to move to new HTTP handlers with CR filtering.

## Testing

Every `WebhookHandler` implementation for every CRD will be done in a separate pull request. All these pull requests will be stacked on top of each other, so that every new is added on top of the previous one. This way it will be possible to test all of them together (which is needed, because it does not make sense to do the filtering on only some CRDs), but implement and review the changes separately.

We also have to adapt existing unit and integration tests.

Therefore we have the following testing tasks:
- [x] update all existing unit tests for `AzureClusterConfig` to use new `WebhookHandler` implementations
- [x] update all existing and affected integration tests to use new `WebhookHandler` implementations
- [x] test changes in test installations

Important note:
*This pull request will be merged only when the testing of all the following related pull requests for all other CRDs is completed (every PR builds on top of the previous one):
- Cluster https://github.com/giantswarm/azure-admission-controller/pull/272
- AzureCluster https://github.com/giantswarm/azure-admission-controller/pull/273
- MachinePool https://github.com/giantswarm/azure-admission-controller/pull/274
- AzureMachinePool https://github.com/giantswarm/azure-admission-controller/pull/275
- AzureMachine https://github.com/giantswarm/azure-admission-controller/pull/278
- Spark https://github.com/giantswarm/azure-admission-controller/pull/279
- AzureClusterConfig _(this PR)_
- AzureConfig https://github.com/giantswarm/azure-admission-controller/pull/281