### PR TITLE
Use right Location parameter coming from config mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use right `Location` parameter coming from `config` mechanism.
+
 ## [3.0.0] - 2021-08-03
 
 ### Added

--- a/helm/azure-admission-controller/templates/deployment.yaml
+++ b/helm/azure-admission-controller/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - --tls-cert-file=/certs/ca.crt
             - --tls-key-file=/certs/tls.key
             - --base-domain={{ .Values.workloadCluster.kubernetes.api.endpointBase }}
-            - --location={{ .Values.provider.location }}
+            - --location={{ .Values.azure.location }}
           volumeMounts:
           - name: {{ include "name" . }}-certificates
             mountPath: "/certs"

--- a/helm/azure-admission-controller/values.yaml
+++ b/helm/azure-admission-controller/values.yaml
@@ -11,7 +11,7 @@ workloadCluster:
     api:
       endpointBase: k8s.test.westeurope.azure.gigantic.io
 
-provider:
+azure:
   location: westeurope
 
 registry:


### PR DESCRIPTION
The location parameter is not coming from the config system and it's using the default value present in `values.yaml`. This works only on installations that match that location, but breaks on the rest.