### PR TITLE
Remove validation of release label on AzureCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove mutations on fields that are already defaulted on `kubectl-gs`.
+- Remove validation that checks that `AzureCluster` and `Cluster` have the same release label.
 
 ## [3.7.0] - 2022-03-21
 

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/giantswarm/microerror"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
-	capiutil "sigs.k8s.io/cluster-api/util"
 
 	"github.com/giantswarm/azure-admission-controller/internal/errors"
 	"github.com/giantswarm/azure-admission-controller/internal/releaseversion"
@@ -60,22 +59,6 @@ func (h *WebhookHandler) validateRelease(ctx context.Context, azureClusterOldCR 
 	newClusterVersion, err := semverhelper.GetSemverFromLabels(azureClusterNewCR.Labels)
 	if err != nil {
 		return microerror.Maskf(errors.ParsingFailedError, "unable to parse version from applied AzureCluster")
-	}
-
-	if !newClusterVersion.Equals(oldClusterVersion) {
-		cluster, err := capiutil.GetOwnerCluster(ctx, h.ctrlClient, azureClusterNewCR.ObjectMeta)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		clusterCRReleaseVersion, err := semverhelper.GetSemverFromLabels(cluster.Labels)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		if !newClusterVersion.Equals(clusterCRReleaseVersion) {
-			return microerror.Maskf(errors.InvalidOperationError, "AzureCluster release version must be set to the same release version as Cluster CR release version label")
-		}
 	}
 
 	return releaseversion.Validate(ctx, h.ctrlClient, oldClusterVersion, newClusterVersion)


### PR DESCRIPTION
In our `azure-admission-controller` we make sure `AzureCluster` has the same `release` label than `Cluster`, but unless I'm missing something... we don't use the `release` label from `AzureCluster` for anything really on `azure-operator`, we use the one in the `Cluster` CR and then in `MachinePools`/`AzureMachinePools` to see how the upgrade is going. So I think we don't need to validate that label at all.
