### PR TITLE
Ignore capi errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore immutability error for `azureCluster.spec.networkSpec.nodeOutboundLB` for legacy clusters to allow migration from v1alpha3 to v1beta1.
+
 ## [4.2.0] - 2022-06-16
 
 ### Added

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -36,6 +36,13 @@ func (h *WebhookHandler) OnUpdateValidate(ctx context.Context, oldObject interfa
 	err = errors.IgnoreCAPIErrorForField("spec.SubscriptionID", err)
 	err = errors.IgnoreCAPIErrorForField("spec.ControlPlaneEndpoint.Host", err)
 	err = errors.IgnoreCAPIErrorForField("spec.ControlPlaneEndpoint.Port", err)
+	isCapi, lerr := generic.IsCAPIRelease(azureClusterOldCR)
+	if lerr != nil {
+		return microerror.Mask(err)
+	}
+	if !isCapi {
+		err = errors.IgnoreCAPIErrorForField("spec.networkSpec.nodeOutboundLB", err)
+	}
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/pkg/azurecluster/validate_update.go
+++ b/pkg/azurecluster/validate_update.go
@@ -36,13 +36,7 @@ func (h *WebhookHandler) OnUpdateValidate(ctx context.Context, oldObject interfa
 	err = errors.IgnoreCAPIErrorForField("spec.SubscriptionID", err)
 	err = errors.IgnoreCAPIErrorForField("spec.ControlPlaneEndpoint.Host", err)
 	err = errors.IgnoreCAPIErrorForField("spec.ControlPlaneEndpoint.Port", err)
-	isCapi, lerr := generic.IsCAPIRelease(azureClusterOldCR)
-	if lerr != nil {
-		return microerror.Mask(err)
-	}
-	if !isCapi {
-		err = errors.IgnoreCAPIErrorForField("spec.networkSpec.nodeOutboundLB", err)
-	}
+	err = errors.IgnoreCAPIErrorForField("spec.networkSpec.nodeOutboundLB", err)
 	if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
When upgrading a v1alpha3 cluster to a v1beta1 one, the newly added fields are being created, but capi admission controller blocks that.
This prevents us from upgrading legacy clusters.

This PR fixes just that.