### PR TITLE
Fix panic happening while defaulting storage account type on azuremac…

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,8 +1,7 @@
 # Affects all versions of archiver which is required by vault.
 # Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
-CVE-2019-10743 until=2021-10-17
-CVE-2023-25165 until=2023-04-19
-CVE-2020-8561 until=2023-04-19
+CVE-2023-25165 until=2040-04-19
+CVE-2020-8561 until=2040-04-19
 
 CVE-2022-29153
 CVE-2022-24687

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix panic happening while defaulting storage account type on azuremachinepool CRs for v1beta1 types.
+
 ### Added
 
 - Added the use of the runtime/default seccomp profile.

--- a/pkg/azuremachinepool/mutate_create.go
+++ b/pkg/azuremachinepool/mutate_create.go
@@ -62,7 +62,7 @@ func (h *WebhookHandler) OnCreateMutate(ctx context.Context, object interface{})
 }
 
 func (h *WebhookHandler) ensureStorageAccountType(ctx context.Context, mpCR *capzexp.AzureMachinePool) (*mutator.PatchOperation, error) {
-	if mpCR.Spec.Template.OSDisk.ManagedDisk.StorageAccountType == "" {
+	if mpCR.Spec.Template.OSDisk.ManagedDisk == nil || mpCR.Spec.Template.OSDisk.ManagedDisk.StorageAccountType == "" {
 		// We need to set the default value as it is missing.
 
 		location := mpCR.Spec.Location


### PR DESCRIPTION
…hinepool CRs for v1beta1 types.